### PR TITLE
Fix for blind position

### DIFF
--- a/custom_components/tuiss2ha/hub.py
+++ b/custom_components/tuiss2ha/hub.py
@@ -220,7 +220,7 @@ class TuissBlind:
 
         decimals = self.split_data(data)
 
-        blindPos = decimals[6]
+        blindPos = (decimals[-3] + (decimals[-2] * 256)) / 10
         _LOGGER.debug("%s: Blind position is %s", self.name, blindPos)
         self._current_cover_position = blindPos
 

--- a/custom_components/tuiss2ha/hub.py
+++ b/custom_components/tuiss2ha/hub.py
@@ -213,12 +213,16 @@ class TuissBlind:
                 self._battery_status = None
             await self.blind_disconnect()
 
+    def return_hex_bytearray(self, x):
+        """make sure we print ascii symbols as hex"""
+        return ''.join([type(x).__name__, "('",
+                    *['\\x'+'{:02x}'.format(i) for i in x], "')"])
 
     async def position_callback(self, sender: BleakGATTCharacteristic, data: bytearray):
         """Wait for response from the blind and updates entity status."""
         _LOGGER.debug("%s: Attempting to get position", self.name)
 
-        decimals = self.split_data(data)
+        decimals = self.split_data(self.return_hex_bytearray(data))
 
         blindPos = (decimals[-3] + (decimals[-2] * 256)) / 10
         _LOGGER.debug("%s: Blind position is %s", self.name, blindPos)

--- a/custom_components/tuiss2ha/hub.py
+++ b/custom_components/tuiss2ha/hub.py
@@ -216,11 +216,11 @@ class TuissBlind:
 
     async def position_callback(self, sender: BleakGATTCharacteristic, data: bytearray):
         """Wait for response from the blind and updates entity status."""
-        _LOGGER.debug("%s: Attempting to get battery status", self.name)
+        _LOGGER.debug("%s: Attempting to get position", self.name)
 
         decimals = self.split_data(data)
 
-        blindPos = (decimals[-3] + (decimals[-2] * 256)) / 10
+        blindPos = decimals[6]
         _LOGGER.debug("%s: Blind position is %s", self.name, blindPos)
         self._current_cover_position = blindPos
 

--- a/custom_components/tuiss2ha/hub.py
+++ b/custom_components/tuiss2ha/hub.py
@@ -192,7 +192,7 @@ class TuissBlind:
         """Wait for response from the blind and updates entity status."""
         _LOGGER.debug("%s: Attempting to get battery status", self.name)
 
-        decimals = self.split_data(data)
+        decimals = self.split_data(self.return_hex_bytearray(data))
 
         if decimals[4] == 210:
             if len(decimals) == 5:

--- a/custom_components/tuiss2ha/hub.py
+++ b/custom_components/tuiss2ha/hub.py
@@ -224,7 +224,7 @@ class TuissBlind:
 
         decimals = self.split_data(self.return_hex_bytearray(data))
 
-        blindPos = (decimals[-3] + (decimals[-2] * 256)) / 10
+        blindPos = (decimals[-4] + (decimals[-3] * 256)) / 10
         _LOGGER.debug("%s: Blind position is %s", self.name, blindPos)
         self._current_cover_position = blindPos
 


### PR DESCRIPTION
added function so bytearray is printed fully as hex.
the split_data function was having issues as ASCII chars in the bytearray were printed as ASCII by default.
Updated calculation.
Updated Debug output to show correct action