### PR TITLE
add function return_hex_bytearray to fix split_data function

### DIFF
--- a/custom_components/tuiss2ha/hub.py
+++ b/custom_components/tuiss2ha/hub.py
@@ -220,7 +220,7 @@ class TuissBlind:
 
         decimals = self.split_data(data)
 
-        blindPos = decimals[6]
+        blindPos = (decimals[-3] + (decimals[-2] * 256)) / 10
         _LOGGER.debug("%s: Blind position is %s", self.name, blindPos)
         self._current_cover_position = blindPos
 

--- a/custom_components/tuiss2ha/hub.py
+++ b/custom_components/tuiss2ha/hub.py
@@ -213,12 +213,16 @@ class TuissBlind:
                 self._battery_status = None
             await self.blind_disconnect()
 
+    def return_hex_bytearray(self, x):
+        """make sure we print ascii symbols as hex"""
+        return ''.join([type(x).__name__, "('",
+                    *['\\x'+'{:02x}'.format(i) for i in x], "')"])
 
     async def position_callback(self, sender: BleakGATTCharacteristic, data: bytearray):
         """Wait for response from the blind and updates entity status."""
         _LOGGER.debug("%s: Attempting to get position", self.name)
 
-        decimals = self.split_data(data)
+        decimals = self.split_data(self.return_hex_bytearray(data))
 
         blindPos = (decimals[-3] + (decimals[-2] * 256)) / 10
         _LOGGER.debug("%s: Blind position is %s", self.name, blindPos)

--- a/custom_components/tuiss2ha/hub.py
+++ b/custom_components/tuiss2ha/hub.py
@@ -216,11 +216,11 @@ class TuissBlind:
 
     async def position_callback(self, sender: BleakGATTCharacteristic, data: bytearray):
         """Wait for response from the blind and updates entity status."""
-        _LOGGER.debug("%s: Attempting to get battery status", self.name)
+        _LOGGER.debug("%s: Attempting to get position", self.name)
 
         decimals = self.split_data(data)
 
-        blindPos = (decimals[-3] + (decimals[-2] * 256)) / 10
+        blindPos = decimals[6]
         _LOGGER.debug("%s: Blind position is %s", self.name, blindPos)
         self._current_cover_position = blindPos
 

--- a/custom_components/tuiss2ha/hub.py
+++ b/custom_components/tuiss2ha/hub.py
@@ -192,7 +192,7 @@ class TuissBlind:
         """Wait for response from the blind and updates entity status."""
         _LOGGER.debug("%s: Attempting to get battery status", self.name)
 
-        decimals = self.split_data(data)
+        decimals = self.split_data(self.return_hex_bytearray(data))
 
         if decimals[4] == 210:
             if len(decimals) == 5:

--- a/custom_components/tuiss2ha/hub.py
+++ b/custom_components/tuiss2ha/hub.py
@@ -213,7 +213,7 @@ class TuissBlind:
                 self._battery_status = None
             await self.blind_disconnect()
 
-            
+
     async def position_callback(self, sender: BleakGATTCharacteristic, data: bytearray):
         """Wait for response from the blind and updates entity status."""
         _LOGGER.debug("%s: Attempting to get position", self.name)

--- a/custom_components/tuiss2ha/hub.py
+++ b/custom_components/tuiss2ha/hub.py
@@ -192,7 +192,7 @@ class TuissBlind:
         """Wait for response from the blind and updates entity status."""
         _LOGGER.debug("%s: Attempting to get battery status", self.name)
 
-        decimals = self.split_data(self.return_hex_bytearray(data))
+        decimals = self.split_data(data)
 
         if decimals[4] == 210:
             if len(decimals) == 5:
@@ -222,7 +222,7 @@ class TuissBlind:
         """Wait for response from the blind and updates entity status."""
         _LOGGER.debug("%s: Attempting to get position", self.name)
 
-        decimals = self.split_data(self.return_hex_bytearray(data))
+        decimals = self.split_data(data)
 
         blindPos = (decimals[-4] + (decimals[-3] * 256)) / 10
         _LOGGER.debug("%s: Blind position is %s", self.name, blindPos)
@@ -233,7 +233,7 @@ class TuissBlind:
 
     def split_data(self, data):
         """Split the byte response into decimal."""
-        customdecode = str(data)
+        customdecode = str(self.return_hex_bytearray(data))
         customdecodesplit = customdecode.split("\\x")
         response = ""
         decimals = []

--- a/custom_components/tuiss2ha/hub.py
+++ b/custom_components/tuiss2ha/hub.py
@@ -235,7 +235,8 @@ class TuissBlind:
 
     def split_data(self, data):
         """Split the byte response into decimal."""
-        customdecode = str(self.return_hex_bytearray(data))
+        data_hex = self.return_hex_bytearray(data)
+        customdecode = str(data_hex)
         customdecodesplit = customdecode.split("\\x")
         response = ""
         decimals = []
@@ -247,7 +248,7 @@ class TuissBlind:
             decimals.append(int(resp, 16))
             x += 1
 
-        _LOGGER.debug("%s: As byte:%s", self.name, data)
+        _LOGGER.debug("%s: As byte:%s", self.name, data_hex)
         _LOGGER.debug("%s: As string:%s", self.name, response)
         _LOGGER.debug("%s: As decimals:%s", self.name, decimals)
         return decimals

--- a/custom_components/tuiss2ha/hub.py
+++ b/custom_components/tuiss2ha/hub.py
@@ -224,7 +224,7 @@ class TuissBlind:
 
         decimals = self.split_data(self.return_hex_bytearray(data))
 
-        blindPos = (decimals[-3] + (decimals[-2] * 256)) / 10
+        blindPos = (decimals[-4] + (decimals[-3] * 256)) / 10
         _LOGGER.debug("%s: Blind position is %s", self.name, blindPos)
         self._current_cover_position = blindPos
 

--- a/custom_components/tuiss2ha/hub.py
+++ b/custom_components/tuiss2ha/hub.py
@@ -195,17 +195,17 @@ class TuissBlind:
         decimals = self.split_data(data)
 
         if decimals[4] == 210:
-            if len(decimals) == 5:
+            if len(decimals) == 7:
                 _LOGGER.debug(
                     "%s: Please charge device", self.name
                 )  # think its based on the length of the response? ff010203d2 (bad) vs ff010203d202e803 (good)
                 self._battery_status = True
-            elif decimals[5] > 10:
+            elif decimals[5] >= 10:
                 _LOGGER.debug(
                     "%s: Please charge device", self.name
                 )  # think its based on the length of the response? ff010203d2 (bad) vs ff010203d202e803 (good)
                 self._battery_status = True
-            elif decimals[5] <= 10:
+            elif decimals[5] < 10:
                 _LOGGER.debug("%s: Battery is good", self.name)
                 self._battery_status = False
             else:

--- a/custom_components/tuiss2ha/hub.py
+++ b/custom_components/tuiss2ha/hub.py
@@ -213,11 +213,7 @@ class TuissBlind:
                 self._battery_status = None
             await self.blind_disconnect()
 
-    def return_hex_bytearray(self, x):
-        """make sure we print ascii symbols as hex"""
-        return ''.join([type(x).__name__, "('",
-                    *['\\x'+'{:02x}'.format(i) for i in x], "')"])
-
+            
     async def position_callback(self, sender: BleakGATTCharacteristic, data: bytearray):
         """Wait for response from the blind and updates entity status."""
         _LOGGER.debug("%s: Attempting to get position", self.name)
@@ -230,6 +226,12 @@ class TuissBlind:
 
         await self.blind_disconnect()
 
+
+    def return_hex_bytearray(self, x):
+        """make sure we print ascii symbols as hex"""
+        return ''.join([type(x).__name__, "('",
+                    *['\\x'+'{:02x}'.format(i) for i in x], "')"])
+    
 
     def split_data(self, data):
         """Split the byte response into decimal."""


### PR DESCRIPTION
added function return_hex_bytearray to return bytearray as hex instead of with ascii chars.
split_data expects all data in hex. 
updated calculation (tested against my blinds TS2900 and TS3000)
updated debug log to print correct function

Sorry for the double pull request, it's my first :)