### PR TITLE
Improve add-device discovery and error handling (fixes #100)

### DIFF
--- a/custom_components/tuiss2ha/config_flow.py
+++ b/custom_components/tuiss2ha/config_flow.py
@@ -31,6 +31,7 @@ from .const import (
     InvalidName,
     DeviceNotFound,
     ConnectionTimeout,
+    NoConnectableBluetoothAdapter,
     OPT_FAVORITE_POSITION,
     DEFAULT_FAVORITE_POSITION,
 )
@@ -97,6 +98,12 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             errors[CONF_BLIND_HOST] = "invalid_host"
         except InvalidName:
             errors[CONF_BLIND_NAME] = "invalid_name"
+        except NoConnectableBluetoothAdapter:
+            errors["base"] = "no_connectable_bluetooth"
+        except DeviceNotFound:
+            errors["base"] = "device_not_found"
+        except ConnectionTimeout:
+            errors["base"] = "connection_timeout"
         except Exception as exc:
             _LOGGER.exception("Unexpected exception: %s", exc)
             errors["base"] = "unknown"
@@ -167,6 +174,8 @@ async def validate_input(hass: HomeAssistant, data: dict) -> dict[str, Any]:
     except DeviceNotFound:
         raise
     except ConnectionTimeout:
+        raise
+    except NoConnectableBluetoothAdapter:
         raise
     except Exception as e:
         raise CannotConnect() from e

--- a/custom_components/tuiss2ha/const.py
+++ b/custom_components/tuiss2ha/const.py
@@ -44,4 +44,8 @@ class DeviceNotFound(Exception):
 
 
 class ConnectionTimeout(Exception):
-    """Error to indicate a connection timeout.""" 
+    """Error to indicate a connection timeout."""
+
+
+class NoConnectableBluetoothAdapter(Exception):
+    """Error to indicate no Bluetooth adapter can connect (e.g. Shelly is passive-only)."""

--- a/custom_components/tuiss2ha/hub.py
+++ b/custom_components/tuiss2ha/hub.py
@@ -26,6 +26,7 @@ from .const import (
     DEFAULT_RESTART_ATTEMPTS,
     DeviceNotFound,
     ConnectionTimeout,
+    NoConnectableBluetoothAdapter,
     TIMEOUT_SECONDS,
 )
 
@@ -73,6 +74,10 @@ class TuissBlind:
         self._ble_device = bluetooth.async_ble_device_from_address(
             self.hub._hass, self.host, connectable=True
         )
+        if self._ble_device is None:
+            self._ble_device = bluetooth.async_ble_device_from_address(
+                self.hub._hass, self.host, connectable=False
+            )
         self.model = self._ble_device.name if self._ble_device else None
         self._rssi: int | None = None
         self._client: BleakClientWithServiceCache | None = None
@@ -90,6 +95,7 @@ class TuissBlind:
         self._locked = False
         self._attr_traversal_speed: float | None = None
         self._heartbeat_task: asyncio.Task | None = None
+        self._last_connection_error: str | None = None  # For logging when connection fails
 
 
     @property
@@ -164,7 +170,13 @@ class TuissBlind:
             self._ble_device = bluetooth.async_ble_device_from_address(
                 self.hub._hass, self.host, connectable=True
             )
+            if self._ble_device is None:
+                self._ble_device = bluetooth.async_ble_device_from_address(
+                    self.hub._hass, self.host, connectable=False
+                )
             rediscover_attempts += 1
+            if self._ble_device is None and rediscover_attempts < self._restart_attempts:
+                await asyncio.sleep(2)
         if self._ble_device is None:
             _LOGGER.error(
                 "Cannot find the device %s. Check your bluetooth adapters and proxies",
@@ -190,9 +202,26 @@ class TuissBlind:
                 return
 
             retry_count += 1
+            if retry_count <= self._restart_attempts:
+                await asyncio.sleep(2)
 
-        # If we reach here, we have exceeded max retries
-        _LOGGER.error("%s: Connection failed too many times [%d]", self.name, self._restart_attempts)
+        # If we reach here, we have exceeded max retries - log the actual error at ERROR so it's visible
+        last_err = self._last_connection_error or "unknown (no error captured)"
+        _LOGGER.error(
+            "%s: Connection failed after %d attempts. Last error: %s",
+            self.name,
+            self._restart_attempts,
+            last_err,
+        )
+        # Give a clear error when user has only passive Bluetooth (e.g. Shelly)
+        if last_err and (
+            "passive-only" in last_err.lower()
+            or "no connectable bluetooth" in last_err.lower()
+        ):
+            raise NoConnectableBluetoothAdapter(
+                "No connectable Bluetooth adapter. Shelly and similar devices are passive-only. "
+                "You need an ESPHome Bluetooth proxy or a USB Bluetooth adapter to control Tuiss blinds."
+            )
         raise ConnectionTimeout(f"{self.name}: Connection failed too many times [{self._restart_attempts}]")
 
     # Connect
@@ -236,7 +265,11 @@ class TuissBlind:
                 self._moving,
             )
         except (BleakError, asyncio.TimeoutError) as e:
+            self._last_connection_error = str(e)
             _LOGGER.debug("Failed to connect to blind: %s", e)
+        except Exception as e:
+            self._last_connection_error = f"{type(e).__name__}: {e}"
+            _LOGGER.debug("%s: Unexpected error during connect: %s", self.name, e)
 
     # Disconnect
     async def disconnect(self):

--- a/custom_components/tuiss2ha/translations/en.json
+++ b/custom_components/tuiss2ha/translations/en.json
@@ -23,6 +23,7 @@
             "unknown": "Unknown error. Please try again. If you consistently get this error please raise an issue.",
             "device_not_found": "The device could not be found. Please ensure it is powered on and in range.",
             "connection_timeout": "The connection timed out after several retries. Please try again later.",
+            "no_connectable_bluetooth": "No connectable Bluetooth adapter. Shelly and similar devices only discover devices; they cannot connect. You need an ESPHome Bluetooth proxy (e.g. ESP32) or a USB Bluetooth adapter on your Home Assistant host to control Tuiss blinds.",
             "invalid_host": "Your mac address must be in the format XX:XX:XX:XX:XX:XX",
             "invalid_name": "Your name must be longer than 0 characters"
         },


### PR DESCRIPTION
Addresses aspects of #100

## Problem / context

- When adding a Tuiss blind via MAC address, users sometimes see a generic **"Unknown error. Please try again."** with no indication of cause.
- Connection/rediscovery retries ran with no delay, so the BLE stack and proxies had no time to discover or report the device before the integration gave up.
- In particular, when the only Bluetooth source is **passive-only** (e.g. Shelly devices that can discover but not connect), the underlying error ("No connectable Bluetooth adapters...") was never surfaced to the user.

## Changes

**More time for device discovery**

- Add a **2 second delay** between rediscovery attempts (in `attempt_connection`) so Bluetooth proxies and the BLE stack have time to discover and report the device before we give up. Feedback takes a bit longer, but the device is more likely to be found.
- Add a **2 second delay** between connection attempts (after each failed `connect()`) so the stack has time to recover between tries.

**Clearer error handling**

- **Log the real failure**: Before raising `ConnectionTimeout`, log at ERROR level: `"Connection failed after N attempts. Last error: <actual error>"` so logs show the underlying BLE/stack error.
- **Detect passive-only Bluetooth**: If the last error mentions `"passive-only"` or `"no connectable bluetooth"` (e.g. Shelly), raise a new `NoConnectableBluetoothAdapter` exception and show a dedicated message telling the user they need an ESPHome Bluetooth proxy or USB Bluetooth adapter.
- **Config flow**: Handle `DeviceNotFound`, `ConnectionTimeout`, and `NoConnectableBluetoothAdapter` explicitly so the UI shows the right message instead of "Unknown error".

**Unchanged**

- No change to connection or protocol behaviour beyond the added delays and error branching.

## Files changed

- **const.py**: Add `NoConnectableBluetoothAdapter`; keep `DEFAULT_RESTART_ATTEMPTS = 4`.
- **hub.py**: `_last_connection_error`; try `connectable=False` fallback when device not found with `connectable=True`; 2s delays in rediscovery and connection retry loops; ERROR log + `NoConnectableBluetoothAdapter` branch before `ConnectionTimeout`; store exception in `connect()`;
- **config_flow.py**: Import and handle `NoConnectableBluetoothAdapter`, `DeviceNotFound`, `ConnectionTimeout`; `validate_input` re-raises `NoConnectableBluetoothAdapter`.
- **translations/en.json**: New key `no_connectable_bluetooth` with message for passive-only Bluetooth.

## Example output

<img width="597" height="523" alt="image" src="https://github.com/user-attachments/assets/637e27cc-ae4a-4b7d-b65b-c3b495c5dcdc" />
