### PR TITLE
Add Battery Reading sensor, position presets, and Bluetooth auto-retry

### DIFF
--- a/custom_components/tuiss2ha/__init__.py
+++ b/custom_components/tuiss2ha/__init__.py
@@ -272,10 +272,11 @@ def _resolve_blind_from_entity_id(hass: HomeAssistant, entity_id: str):
     entry = ent_reg.async_get(entity_id)
     if not entry or entry.platform != DOMAIN:
         return None
-    # unique_id pattern: "<blind_id>_cover" or "<blind_id>_preset_select"
+    # unique_id pattern is "<blind_id>_<suffix>" where suffix may itself
+    # contain underscores (e.g. "_preset_select"). Strip the longest
+    # known suffix first so we don't lop off only the trailing word.
     unique_id = entry.unique_id or ""
-    blind_id = unique_id.rsplit("_", 1)[0] if "_" in unique_id else None
-    # _preset_select uses two underscores at the end; handle that case too
+    blind_id: str | None = None
     for suffix in ("_preset_select", "_cover"):
         if unique_id.endswith(suffix):
             blind_id = unique_id[: -len(suffix)]

--- a/custom_components/tuiss2ha/__init__.py
+++ b/custom_components/tuiss2ha/__init__.py
@@ -45,6 +45,7 @@ _LOGGER = logging.getLogger(__name__)
 
 # Service names for position presets
 SERVICE_SAVE_PRESET = "save_preset"
+SERVICE_SAVE_CURRENT_AS_PRESET = "save_current_position_as_preset"
 SERVICE_DELETE_PRESET = "delete_preset"
 SERVICE_APPLY_PRESET = "apply_preset"
 
@@ -56,6 +57,12 @@ SAVE_PRESET_SCHEMA = vol.Schema(
         vol.Required("entity_id"): cv.entity_id,
         vol.Required("name"): _PRESET_NAME_SCHEMA,
         vol.Required("position"): _PRESET_POSITION_SCHEMA,
+    }
+)
+SAVE_CURRENT_AS_PRESET_SCHEMA = vol.Schema(
+    {
+        vol.Required("entity_id"): cv.entity_id,
+        vol.Required("name"): _PRESET_NAME_SCHEMA,
     }
 )
 DELETE_PRESET_SCHEMA = vol.Schema(
@@ -305,6 +312,21 @@ def _async_register_preset_services(hass: HomeAssistant) -> None:
             "%s: Saved preset %r at %s%%", blind.name, name, position
         )
 
+    async def _handle_save_current_as_preset(call: ServiceCall) -> None:
+        entity_id = call.data["entity_id"]
+        name = call.data["name"]
+        blind = _resolve_blind_from_entity_id(hass, entity_id)
+        if not blind:
+            _LOGGER.error(
+                "save_current_position_as_preset: cannot resolve blind for %s",
+                entity_id,
+            )
+            return
+        # Delegate to the blind so the rounding / persistence / refusal
+        # rules live in one place. Returning None means the position
+        # isn't known yet — the blind has already logged at warning.
+        await blind.async_save_current_as_preset(name)
+
     async def _handle_delete_preset(call: ServiceCall) -> None:
         entity_id = call.data["entity_id"]
         name = call.data["name"]
@@ -359,6 +381,12 @@ def _async_register_preset_services(hass: HomeAssistant) -> None:
 
     hass.services.async_register(
         DOMAIN, SERVICE_SAVE_PRESET, _handle_save_preset, schema=SAVE_PRESET_SCHEMA
+    )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_SAVE_CURRENT_AS_PRESET,
+        _handle_save_current_as_preset,
+        schema=SAVE_CURRENT_AS_PRESET_SCHEMA,
     )
     hass.services.async_register(
         DOMAIN, SERVICE_DELETE_PRESET, _handle_delete_preset, schema=DELETE_PRESET_SCHEMA

--- a/custom_components/tuiss2ha/__init__.py
+++ b/custom_components/tuiss2ha/__init__.py
@@ -31,6 +31,8 @@ from .const import (
     DEFAULT_BLIND_SPEED,
     OPT_BATTERY_CHECK_DAYS,
     DEFAULT_BATTERY_CHECK_DAYS,
+    OPT_OPERATION_RETRY,
+    DEFAULT_OPERATION_RETRY,
     DeviceNotFound,
     ConnectionTimeout,
     SPEED_CONTROL_SUPPORTED_MODELS,
@@ -114,6 +116,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 OPT_RESTART_ATTEMPTS: DEFAULT_RESTART_ATTEMPTS,
                 OPT_BLIND_SPEED: DEFAULT_BLIND_SPEED,
                 OPT_BATTERY_CHECK_DAYS: DEFAULT_BATTERY_CHECK_DAYS,
+                OPT_OPERATION_RETRY: DEFAULT_OPERATION_RETRY,
             },
         )
 
@@ -131,6 +134,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         )
         blind._restart_attempts = entry.options.get(
             OPT_RESTART_ATTEMPTS, DEFAULT_RESTART_ATTEMPTS
+        )
+        blind._operation_retry = entry.options.get(
+            OPT_OPERATION_RETRY, DEFAULT_OPERATION_RETRY
         )
 
         if blind._position_on_restart:
@@ -185,12 +191,14 @@ async def update_listener(hass: HomeAssistant, entry: ConfigEntry):
 
     # Apply battery check days option to all blinds immediately so changes take effect
     battery_days = entry.options.get(OPT_BATTERY_CHECK_DAYS, DEFAULT_BATTERY_CHECK_DAYS)
+    operation_retry = entry.options.get(OPT_OPERATION_RETRY, DEFAULT_OPERATION_RETRY)
     for b in hub.blinds:
         try:
             b._battery_check_days = battery_days
+            b._operation_retry = operation_retry
             b.publish_updates()  # Notify sensors of the change
         except (AttributeError, TypeError) as e:
-            _LOGGER.debug("Failed to apply battery_check_days to blind %s: %s", getattr(b, "name", "unknown"), e)
+            _LOGGER.debug("Failed to apply options to blind %s: %s", getattr(b, "name", "unknown"), e)
 
     # Retrieve the updated option value for speed
     new_blind_speed = entry.options.get(OPT_BLIND_SPEED, DEFAULT_BLIND_SPEED)

--- a/custom_components/tuiss2ha/__init__.py
+++ b/custom_components/tuiss2ha/__init__.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 import logging
 import asyncio
 
+import voluptuous as vol
+
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.components import bluetooth
 from homeassistant.components.bluetooth import (
@@ -14,7 +16,7 @@ from homeassistant.components.bluetooth import (
     async_register_callback,
 )
 from homeassistant.const import CONF_ADDRESS, Platform
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import config_validation as cv, device_registry as dr, entity_registry as er
 
 from .hub import Hub
 from .const import (
@@ -36,17 +38,48 @@ from .const import (
 
 
 
-PLATFORMS: list[str] = ["cover", "binary_sensor", "sensor", "button"]
+PLATFORMS: list[str] = ["cover", "binary_sensor", "sensor", "button", "select"]
 _LOGGER = logging.getLogger(__name__)
+
+# Service names for position presets
+SERVICE_SAVE_PRESET = "save_preset"
+SERVICE_DELETE_PRESET = "delete_preset"
+SERVICE_APPLY_PRESET = "apply_preset"
+
+_PRESET_NAME_SCHEMA = vol.All(cv.string, vol.Length(min=1, max=64))
+_PRESET_POSITION_SCHEMA = vol.All(vol.Coerce(int), vol.Range(min=0, max=100))
+
+SAVE_PRESET_SCHEMA = vol.Schema(
+    {
+        vol.Required("entity_id"): cv.entity_id,
+        vol.Required("name"): _PRESET_NAME_SCHEMA,
+        vol.Required("position"): _PRESET_POSITION_SCHEMA,
+    }
+)
+DELETE_PRESET_SCHEMA = vol.Schema(
+    {
+        vol.Required("entity_id"): cv.entity_id,
+        vol.Required("name"): _PRESET_NAME_SCHEMA,
+    }
+)
+APPLY_PRESET_SCHEMA = vol.Schema(
+    {
+        vol.Required("entity_id"): cv.entity_id,
+        vol.Required("name"): _PRESET_NAME_SCHEMA,
+    }
+)
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Tuiss2HA from a config entry."""
     hub = Hub(hass, entry.data[CONF_BLIND_HOST], entry.data[CONF_BLIND_NAME])
 
     for blind in hub.blinds:
-        
+
         # Load timers
         await blind.async_load_timers()
+
+        # Load position presets (HA-side named positions)
+        await blind.async_load_presets()
         
         # Clean up old duplicate network MAC connections from the device registry DEPRICATE IN FUTURE RELEASE
         device_registry = dr.async_get(hass)
@@ -116,6 +149,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = hub
     entry.async_on_unload(entry.add_update_listener(update_listener))
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    # Register preset services once per HA process. Storage is per-blind so
+    # the handlers themselves resolve the target via cover entity_id.
+    _async_register_preset_services(hass)
 
     @callback
     def _async_discovered_device(
@@ -207,3 +244,117 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok
+
+
+def _resolve_blind_from_entity_id(hass: HomeAssistant, entity_id: str):
+    """Resolve a TuissBlind from a cover/select entity_id, or None.
+
+    Accepts the cover entity (preferred) or the preset select entity for the
+    same blind. Looks up the blind via the entity unique_id which encodes the
+    blind_id.
+    """
+    ent_reg = er.async_get(hass)
+    entry = ent_reg.async_get(entity_id)
+    if not entry or entry.platform != DOMAIN:
+        return None
+    # unique_id pattern: "<blind_id>_cover" or "<blind_id>_preset_select"
+    unique_id = entry.unique_id or ""
+    blind_id = unique_id.rsplit("_", 1)[0] if "_" in unique_id else None
+    # _preset_select uses two underscores at the end; handle that case too
+    for suffix in ("_preset_select", "_cover"):
+        if unique_id.endswith(suffix):
+            blind_id = unique_id[: -len(suffix)]
+            break
+    if not blind_id:
+        return None
+    for hub in hass.data.get(DOMAIN, {}).values():
+        if not isinstance(hub, Hub):
+            continue
+        for blind in hub.blinds:
+            if blind.blind_id == blind_id:
+                return blind
+    return None
+
+
+@callback
+def _async_register_preset_services(hass: HomeAssistant) -> None:
+    """Register preset services once per HA process."""
+    if hass.services.has_service(DOMAIN, SERVICE_SAVE_PRESET):
+        return
+
+    async def _handle_save_preset(call: ServiceCall) -> None:
+        entity_id = call.data["entity_id"]
+        name = call.data["name"]
+        position = call.data["position"]
+        blind = _resolve_blind_from_entity_id(hass, entity_id)
+        if not blind:
+            _LOGGER.error("save_preset: cannot resolve blind for %s", entity_id)
+            return
+        blind.presets[name] = int(position)
+        await blind.async_save_presets()
+        blind.publish_updates()
+        _LOGGER.info(
+            "%s: Saved preset %r at %s%%", blind.name, name, position
+        )
+
+    async def _handle_delete_preset(call: ServiceCall) -> None:
+        entity_id = call.data["entity_id"]
+        name = call.data["name"]
+        blind = _resolve_blind_from_entity_id(hass, entity_id)
+        if not blind:
+            _LOGGER.error("delete_preset: cannot resolve blind for %s", entity_id)
+            return
+        if name not in blind.presets:
+            _LOGGER.warning(
+                "%s: delete_preset: preset %r not found", blind.name, name
+            )
+            return
+        blind.presets.pop(name)
+        await blind.async_save_presets()
+        blind.publish_updates()
+        _LOGGER.info("%s: Deleted preset %r", blind.name, name)
+
+    async def _handle_apply_preset(call: ServiceCall) -> None:
+        entity_id = call.data["entity_id"]
+        name = call.data["name"]
+        blind = _resolve_blind_from_entity_id(hass, entity_id)
+        if not blind:
+            _LOGGER.error("apply_preset: cannot resolve blind for %s", entity_id)
+            return
+        if name not in blind.presets:
+            _LOGGER.warning(
+                "%s: apply_preset: preset %r not found", blind.name, name
+            )
+            return
+        position = blind.presets[name]
+
+        # Resolve the cover entity for this blind so the move is dispatched
+        # via the existing cover.set_cover_position service.
+        ent_reg = er.async_get(hass)
+        cover_entity_id = ent_reg.async_get_entity_id(
+            Platform.COVER, DOMAIN, f"{blind.blind_id}_cover"
+        )
+        if not cover_entity_id:
+            _LOGGER.error(
+                "%s: apply_preset: cover entity not found", blind.name
+            )
+            return
+        await hass.services.async_call(
+            "cover",
+            "set_cover_position",
+            {"entity_id": cover_entity_id, "position": position},
+            blocking=False,
+        )
+        _LOGGER.info(
+            "%s: Applied preset %r -> %s%%", blind.name, name, position
+        )
+
+    hass.services.async_register(
+        DOMAIN, SERVICE_SAVE_PRESET, _handle_save_preset, schema=SAVE_PRESET_SCHEMA
+    )
+    hass.services.async_register(
+        DOMAIN, SERVICE_DELETE_PRESET, _handle_delete_preset, schema=DELETE_PRESET_SCHEMA
+    )
+    hass.services.async_register(
+        DOMAIN, SERVICE_APPLY_PRESET, _handle_apply_preset, schema=APPLY_PRESET_SCHEMA
+    )

--- a/custom_components/tuiss2ha/config_flow.py
+++ b/custom_components/tuiss2ha/config_flow.py
@@ -37,6 +37,8 @@ from .const import (
     DEFAULT_FAVORITE_POSITION,
     OPT_BATTERY_CHECK_DAYS,
     DEFAULT_BATTERY_CHECK_DAYS,
+    OPT_OPERATION_RETRY,
+    DEFAULT_OPERATION_RETRY,
 )
 from .hub import Hub
 
@@ -262,6 +264,14 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                     OPT_RESTART_ATTEMPTS, DEFAULT_RESTART_ATTEMPTS
                 ),
             ): int,
+            vol.Optional(
+                OPT_OPERATION_RETRY,
+                default=self.config_entry.options.get(
+                    OPT_OPERATION_RETRY, DEFAULT_OPERATION_RETRY
+                ),
+            ): selector.NumberSelector(
+                selector.NumberSelectorConfig(min=1, max=5, step=1, mode="box")
+            ),
             vol.Optional(
                 OPT_BATTERY_CHECK_DAYS,
                 default=self.config_entry.options.get(

--- a/custom_components/tuiss2ha/const.py
+++ b/custom_components/tuiss2ha/const.py
@@ -40,6 +40,19 @@ DEFAULT_RESTART_POSITION = False
 OPT_RESTART_ATTEMPTS = "blind_restart_attempts"
 DEFAULT_RESTART_ATTEMPTS = 4
 
+# Per-operation retry: how many times a user-facing BLE op (set_position,
+# stop, set_speed, get_battery_status, etc.) may be re-attempted on a
+# transient failure before the error surfaces to HA. 1 disables retries.
+OPT_OPERATION_RETRY = "blind_operation_retry"
+DEFAULT_OPERATION_RETRY = 2
+
+# Exponential backoff between connection retries. Sequence is
+# BASE * 2 ** (n-1), capped at MAX, plus up to JITTER seconds of
+# randomness so multiple blinds don't re-try in lockstep.
+BACKOFF_BASE_SECONDS = 1.0
+BACKOFF_MAX_SECONDS = 16.0
+BACKOFF_JITTER_SECONDS = 0.5
+
 OPT_BLIND_SPEED = "blind_speed"
 DEFAULT_BLIND_SPEED = "Standard"
 BLIND_SPEED_LIST = ["Standard", "Comfort", "Slow"]

--- a/custom_components/tuiss2ha/cover.py
+++ b/custom_components/tuiss2ha/cover.py
@@ -33,15 +33,11 @@ from homeassistant.exceptions import HomeAssistantError
 
 from .const import (
     DOMAIN,
-    OPT_RESTART_ATTEMPTS,
-    OPT_RESTART_POSITION,
     BLIND_SPEED_LIST,
     OPT_BLIND_SPEED,
     SPEED_CONTROL_SUPPORTED_MODELS,
     OPT_FAVORITE_POSITION,
     DEFAULT_FAVORITE_POSITION,
-    OPT_BATTERY_CHECK_DAYS,
-    DEFAULT_BATTERY_CHECK_DAYS,
     ConnectionTimeout,
     DeviceNotFound,
 )
@@ -265,12 +261,12 @@ class Tuiss(CoverEntity, RestoreEntity):
         self._start_time: datetime.datetime | None = None
         self._end_time: datetime.datetime | None = None
         self._attr_mac_address = self._blind.host
-        self._blind._restart_attempts = config.options.get(OPT_RESTART_ATTEMPTS)
-        self._blind._position_on_restart = config.options.get(OPT_RESTART_POSITION)
-        # Number of days between automatic battery checks when blinds move (0 = disabled)
-        self._blind._battery_check_days = config.options.get(
-            OPT_BATTERY_CHECK_DAYS, DEFAULT_BATTERY_CHECK_DAYS
-        )
+        # Option-driven blind state is seeded centrally in __init__.py's
+        # async_setup_entry so it stays consistent across all option keys
+        # (including new ones like _operation_retry). Don't repeat that
+        # seeding here — re-reading from config_entry.options without a
+        # default would overwrite the seeded values with None for any
+        # entry that hasn't yet had its options fully populated.
 
     @property
     def state(self):

--- a/custom_components/tuiss2ha/hub.py
+++ b/custom_components/tuiss2ha/hub.py
@@ -751,6 +751,31 @@ class TuissBlind:
         """Persist position presets to storage."""
         await self._presets_store.async_save(self.presets)
 
+    async def async_save_current_as_preset(self, name: str) -> int | None:
+        """Save the live cover position under ``name`` as a preset.
+
+        Returns the integer position that was stored, or None if the
+        position is currently unknown (never been read). Callers are
+        expected to surface an appropriate user-facing message in the
+        None case — the method itself only logs at warning level.
+        """
+        current = self._current_cover_position
+        if current is None:
+            _LOGGER.warning(
+                "%s: Cannot save preset %r — current position is unknown",
+                self.name, name,
+            )
+            return None
+        position = int(round(current))
+        self.presets[name] = position
+        await self.async_save_presets()
+        self.publish_updates()
+        _LOGGER.info(
+            "%s: Saved preset %r at current position %s%% (raw %s)",
+            self.name, name, position, current,
+        )
+        return position
+
 
     async def async_add_timer(self, days: list[str], time_str: str, position: float) -> str:
         """Add a new schedule."""

--- a/custom_components/tuiss2ha/hub.py
+++ b/custom_components/tuiss2ha/hub.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import datetime
+import random
 import uuid
 
 from bleak.backends.characteristic import BleakGATTCharacteristic
@@ -30,6 +31,10 @@ from .const import (
     CONNECTION_MESSAGE,
     INITIALIZATION_MESSAGE,
     DEFAULT_RESTART_ATTEMPTS,
+    DEFAULT_OPERATION_RETRY,
+    BACKOFF_BASE_SECONDS,
+    BACKOFF_MAX_SECONDS,
+    BACKOFF_JITTER_SECONDS,
     DeviceNotFound,
     ConnectionTimeout,
     NoConnectableBluetoothAdapter,
@@ -118,6 +123,9 @@ class TuissBlind:
         self._desired_position: int | None = None
         self._desired_orientation = False
         self._restart_attempts: int | None = None
+        # Per-operation retry count (1 = no retry, 2 = single retry, etc.).
+        # Seeded from options at boot via __init__.async_setup_entry.
+        self._operation_retry: int | None = None
         self._position_on_restart: bool | None = None
         self._blind_speed: str | None = None
         self._locked = False
@@ -175,6 +183,20 @@ class TuissBlind:
     ## CONNECTION METHODS ############################################################################
     ##################################################################################################
 
+    @staticmethod
+    def _backoff_delay(attempt_index: int) -> float:
+        """Compute exponential backoff delay for the Nth retry (1-indexed).
+
+        Sequence: BACKOFF_BASE * 2 ** (n-1), capped at BACKOFF_MAX, plus
+        up to BACKOFF_JITTER seconds of randomness so multiple blinds
+        recovering at once don't re-try in lockstep.
+        """
+        delay = min(
+            BACKOFF_BASE_SECONDS * (2 ** max(0, attempt_index - 1)),
+            BACKOFF_MAX_SECONDS,
+        )
+        return delay + random.uniform(0, BACKOFF_JITTER_SECONDS)
+
     # Attempt Connections
     async def attempt_connection(self):
         """Attempt to connect to the blind."""
@@ -198,7 +220,7 @@ class TuissBlind:
                 )
             rediscover_attempts += 1
             if self._ble_device is None and rediscover_attempts < self._restart_attempts:
-                await asyncio.sleep(2)
+                await asyncio.sleep(self._backoff_delay(rediscover_attempts))
         if self._ble_device is None:
             _LOGGER.error(
                 "Cannot find the device %s. Check your bluetooth adapters and proxies",
@@ -225,7 +247,7 @@ class TuissBlind:
 
             retry_count += 1
             if retry_count <= self._restart_attempts:
-                await asyncio.sleep(2)
+                await asyncio.sleep(self._backoff_delay(retry_count - 1))
 
         # If we reach here, we have exceeded max retries - log the actual error at ERROR so it's visible
         last_err = self._last_connection_error or "unknown (no error captured)"
@@ -245,6 +267,65 @@ class TuissBlind:
                 "You need an ESPHome Bluetooth proxy or a USB Bluetooth adapter to control Tuiss blinds."
             )
         raise ConnectionTimeout(f"{self.name}: Connection failed too many times [{self._restart_attempts}]")
+
+    async def _retry_operation(self, op_name: str, coro_factory, *,
+                                max_attempts: int | None = None):
+        """Retry a BLE operation on transient failure with reconnect.
+
+        Most BLE errors leave the client in a stale state, so we force a
+        disconnect between attempts and let the next call to
+        ``attempt_connection`` (or ``ensure_connected``) re-establish a
+        clean session.
+
+        Args:
+            op_name: human-readable name used only for logging.
+            coro_factory: zero-arg callable returning a fresh awaitable on
+                each call. Each retry must build a new awaitable, so a
+                lambda or local async closure is the right shape.
+            max_attempts: total tries including the first. Defaults to
+                ``self._operation_retry`` (configured via the
+                ``blind_operation_retry`` option).
+
+        Transient (retried): BleakError, asyncio.TimeoutError,
+            ConnectionTimeout, RuntimeError.
+        Non-transient (raised immediately): DeviceNotFound,
+            NoConnectableBluetoothAdapter, ValueError, AssertionError.
+            These either mean the device is permanently unreachable or
+            the call is malformed — retrying would mask the bug.
+
+        Re-raises the last transient exception if all attempts fail.
+        """
+        if max_attempts is None:
+            max_attempts = self._operation_retry or DEFAULT_OPERATION_RETRY
+        if max_attempts < 1:
+            max_attempts = 1
+        last_err: Exception | None = None
+        for attempt in range(1, max_attempts + 1):
+            try:
+                return await coro_factory()
+            except (DeviceNotFound, NoConnectableBluetoothAdapter,
+                    ValueError, AssertionError):
+                # Non-transient — fail fast
+                raise
+            except (BleakError, asyncio.TimeoutError, ConnectionTimeout,
+                    RuntimeError) as e:
+                last_err = e
+                _LOGGER.warning(
+                    "%s: %s attempt %d/%d failed: %s",
+                    self.name, op_name, attempt, max_attempts, e,
+                )
+                if attempt < max_attempts:
+                    # Best-effort cleanup; suppress further failures so
+                    # the next attempt still gets to run.
+                    try:
+                        await self.disconnect()
+                    except Exception:  # noqa: BLE001
+                        pass
+                    # Short, jittered pause before the next try to give
+                    # the BT proxy time to recover.
+                    await asyncio.sleep(1.0 + random.uniform(0, 0.5))
+        assert last_err is not None
+        raise last_err
 
     # Connect
     async def connect(self):
@@ -332,7 +413,14 @@ class TuissBlind:
     ## SET METHODS ###################################################################################
     ##################################################################################################
     async def set_position(self, userPercent) -> None:
-        """Set the position of the blind converting from HA to Tuiss first."""
+        """Set the position of the blind, retrying transient BLE errors."""
+        await self._retry_operation(
+            "set_position",
+            lambda: self._set_position_once(userPercent),
+        )
+
+    async def _set_position_once(self, userPercent) -> None:
+        """Single attempt at setting the position. Wrapped by ``set_position``."""
 
         await self.ensure_connected()
 
@@ -354,7 +442,13 @@ class TuissBlind:
         await self.send_command(UUID, command)  # send the command
 
     async def stop(self) -> None:
-        """Stop the blind at current position."""
+        """Stop the blind at current position, retrying transient BLE errors."""
+        if self._moving == 0:
+            return
+        await self._retry_operation("stop", self._stop_once)
+
+    async def _stop_once(self) -> None:
+        """Single attempt at stopping the blind. Wrapped by ``stop``."""
         _LOGGER.debug("%s: Attempting to stop the blind.", self.name)
         command = bytes.fromhex(CMD_STOP)
 
@@ -374,7 +468,11 @@ class TuissBlind:
 
 
     async def set_speed(self) -> None:
-        """Set the speed for supported blind types"""
+        """Set the blind speed, retrying transient BLE errors."""
+        await self._retry_operation("set_speed", self._set_speed_once)
+
+    async def _set_speed_once(self) -> None:
+        """Single attempt at setting the speed. Wrapped by ``set_speed``."""
         _LOGGER.debug("%s: Attempting to set the blind speed", self.name)
         match self._blind_speed:
             case "Standard":
@@ -395,7 +493,7 @@ class TuissBlind:
 
 
         await self.ensure_connected()
-        
+
         # send the command
         try:
             if self._client and self._client.is_connected:
@@ -409,14 +507,21 @@ class TuissBlind:
         finally:
             # Always disconnect after set_speed operation
             await self.disconnect()
-        
+
 
     ##################################################################################################
     ## GET METHODS ###################################################################################
     ##################################################################################################
 
-    async def get_from_blind(self, command, callback) -> None:
-        """Get the battery state from the blind as good or bad."""
+    async def get_from_blind(self, command: bytes, callback) -> None:
+        """Read a value from the blind, retrying transient BLE errors."""
+        await self._retry_operation(
+            "get_from_blind",
+            lambda: self._get_from_blind_once(command, callback),
+        )
+
+    async def _get_from_blind_once(self, command: bytes, callback) -> None:
+        """Single attempt at reading a value from the blind."""
 
         # connect to the blind first
         await self.ensure_connected()

--- a/custom_components/tuiss2ha/hub.py
+++ b/custom_components/tuiss2ha/hub.py
@@ -129,6 +129,15 @@ class TuissBlind:
         self.timers = {}
         self._store = Store(self.hub._hass, 1, f"tuiss2ha_{self.host.replace(':', '').lower()}_schedules")
         self._limits_heartbeat_task: asyncio.Task | None = None
+        # Per-blind named position presets ({"Morning": 100, "Movie": 30, ...}).
+        # Stored in HA (separate from on-blind firmware timers) so users can
+        # back them up via HA snapshots and edit via service calls.
+        self.presets: dict[str, int] = {}
+        self._presets_store = Store(
+            self.hub._hass,
+            1,
+            f"tuiss2ha_{self.host.replace(':', '').lower()}_presets",
+        )
 
 
     @property
@@ -598,6 +607,35 @@ class TuissBlind:
     async def async_save_timer(self) -> None:
         """Save schedules to storage."""
         await self._store.async_save(self.timers)
+
+
+    async def async_load_presets(self) -> None:
+        """Load stored position presets."""
+        stored = await self._presets_store.async_load()
+        if stored and isinstance(stored, dict):
+            # Defensive: coerce values to int and drop anything malformed
+            # so a hand-edited or corrupt file can't crash the entity.
+            clean: dict[str, int] = {}
+            for name, position in stored.items():
+                try:
+                    pos_int = int(position)
+                except (TypeError, ValueError):
+                    _LOGGER.warning(
+                        "%s: Dropping preset %r with invalid position %r",
+                        self.name, name, position,
+                    )
+                    continue
+                if not isinstance(name, str) or not name:
+                    continue
+                if 0 <= pos_int <= 100:
+                    clean[name] = pos_int
+            self.presets = clean
+        else:
+            self.presets = {}
+
+    async def async_save_presets(self) -> None:
+        """Persist position presets to storage."""
+        await self._presets_store.async_save(self.presets)
 
 
     async def async_add_timer(self, days: list[str], time_str: str, position: float) -> str:

--- a/custom_components/tuiss2ha/hub.py
+++ b/custom_components/tuiss2ha/hub.py
@@ -114,11 +114,14 @@ class TuissBlind:
         # Raw integer reading parsed from the long-form battery response.
         # The firmware sends bytes [6..8] (LL HH after the status nibble)
         # which we expose as a little-endian u16. The actual scale is
-        # currently UNKNOWN — early samples like 1000 fit a millivolt
-        # reading, but later samples like 59492 don't fit any obvious
-        # voltage / percentage scheme. Keep the value opaque ("Battery
-        # Reading") and expose the full payload hex below so users can
-        # collect calibration data.
+        # currently UNKNOWN. Observed samples on real hardware:
+        #   - 1000  (full battery on a fresh TS2600 install — fits a
+        #            millivolt reading hypothesis but unconfirmed)
+        #   - 59492 (also full battery on a different TS2600 — clearly
+        #            doesn't fit voltage or 0-100% scaling)
+        # Until we have a discharge curve from at least one device, the
+        # value is opaque. Users / maintainer: please report your reading
+        # plus the payload_hex attribute so we can decode the format.
         self._battery_level_raw: int | None = None
         # Hex of every byte after the 0xd2 status nibble (decimals[5:]).
         # Lets users / maintainer reverse-engineer the encoding without
@@ -311,7 +314,7 @@ class TuissBlind:
         last_err: Exception | None = None
         for attempt in range(1, max_attempts + 1):
             try:
-                return await coro_factory()
+                result = await coro_factory()
             except (DeviceNotFound, NoConnectableBluetoothAdapter,
                     ValueError, AssertionError):
                 # Non-transient — fail fast
@@ -333,6 +336,15 @@ class TuissBlind:
                     # Short, jittered pause before the next try to give
                     # the BT proxy time to recover.
                     await asyncio.sleep(1.0 + random.uniform(0, 0.5))
+            else:
+                # Coro returned successfully. Record-keeping so users can
+                # tell from the logs when retry actually saved a call.
+                if attempt > 1:
+                    _LOGGER.debug(
+                        "%s: %s succeeded on attempt %d/%d",
+                        self.name, op_name, attempt, max_attempts,
+                    )
+                return result
         assert last_err is not None
         raise last_err
 

--- a/custom_components/tuiss2ha/hub.py
+++ b/custom_components/tuiss2ha/hub.py
@@ -106,6 +106,11 @@ class TuissBlind:
         self._client: BleakClientWithServiceCache | None = None
         self._callbacks = set()
         self._battery_status = False
+        # Raw integer battery reading parsed from the long-form battery
+        # response. Scale is currently unknown (firmware sends LE u16
+        # bytes [6..8] alongside the status nibble) — exposed as a
+        # diagnostic sensor so users can collect calibration samples.
+        self._battery_level_raw: int | None = None
         self._moving = 0
         self._is_stopping = False
         self._stopped_event = asyncio.Event()
@@ -776,6 +781,16 @@ class TuissBlind:
             else:
                 _LOGGER.debug("%s: Battery logic is wrong", self.name)
                 self._battery_status = None
+            # Capture raw battery level when the long-form frame is present.
+            # Layout (good response): ff 01 02 03 d2 SS LL HH
+            # - decimals[5] (SS): status nibble already used for low-battery gate
+            # - decimals[6..8] (LL HH): little-endian u16, raw level reported
+            #   by firmware. Scale TBD — exposed verbatim for users / maintainer
+            #   to collect calibration data toward a future percentage sensor.
+            if len(decimals) >= 8:
+                self._battery_level_raw = decimals[6] | (decimals[7] << 8)
+            else:
+                self._battery_level_raw = None
             # Record time of this battery check
             try:
                 self._last_battery_check = dt_util.now()

--- a/custom_components/tuiss2ha/hub.py
+++ b/custom_components/tuiss2ha/hub.py
@@ -111,11 +111,20 @@ class TuissBlind:
         self._client: BleakClientWithServiceCache | None = None
         self._callbacks = set()
         self._battery_status = False
-        # Raw integer battery reading parsed from the long-form battery
-        # response. Scale is currently unknown (firmware sends LE u16
-        # bytes [6..8] alongside the status nibble) — exposed as a
-        # diagnostic sensor so users can collect calibration samples.
+        # Raw integer reading parsed from the long-form battery response.
+        # The firmware sends bytes [6..8] (LL HH after the status nibble)
+        # which we expose as a little-endian u16. The actual scale is
+        # currently UNKNOWN — early samples like 1000 fit a millivolt
+        # reading, but later samples like 59492 don't fit any obvious
+        # voltage / percentage scheme. Keep the value opaque ("Battery
+        # Reading") and expose the full payload hex below so users can
+        # collect calibration data.
         self._battery_level_raw: int | None = None
+        # Hex of every byte after the 0xd2 status nibble (decimals[5:]).
+        # Lets users / maintainer reverse-engineer the encoding without
+        # waiting for new sensor builds. Empty string when no long-form
+        # frame has been received yet.
+        self._battery_payload_hex: str | None = None
         self._moving = 0
         self._is_stopping = False
         self._stopped_event = asyncio.Event()
@@ -924,16 +933,31 @@ class TuissBlind:
             else:
                 _LOGGER.debug("%s: Battery logic is wrong", self.name)
                 self._battery_status = None
-            # Capture raw battery level when the long-form frame is present.
-            # Layout (good response): ff 01 02 03 d2 SS LL HH
-            # - decimals[5] (SS): status nibble already used for low-battery gate
-            # - decimals[6..8] (LL HH): little-endian u16, raw level reported
-            #   by firmware. Scale TBD — exposed verbatim for users / maintainer
-            #   to collect calibration data toward a future percentage sensor.
+            # Capture the raw battery payload reported by the firmware.
+            # Layout: ff 01 02 03 d2 SS [extra...]
+            # The bytes after the status nibble carry the raw level reading
+            # but their encoding is currently UNKNOWN — sample values seen
+            # so far range from 1000 to 59492 which doesn't fit a single
+            # voltage or percentage scheme. We expose:
+            #   - LE u16 of bytes [6..8] for back-compat with the diagnostic
+            #     sensor introduced in commit ee254a7
+            #   - the full hex of bytes [5:] so users / maintainer can
+            #     reverse-engineer the format from real samples
             if len(decimals) >= 8:
                 self._battery_level_raw = decimals[6] | (decimals[7] << 8)
             else:
                 self._battery_level_raw = None
+            if len(decimals) > 5:
+                self._battery_payload_hex = bytes(decimals[5:]).hex()
+            else:
+                self._battery_payload_hex = ""
+            _LOGGER.debug(
+                "%s: Battery payload (status=%s reading=%s hex=%s)",
+                self.name,
+                decimals[5] if len(decimals) > 5 else None,
+                self._battery_level_raw,
+                self._battery_payload_hex,
+            )
             # Record time of this battery check
             try:
                 self._last_battery_check = dt_util.now()

--- a/custom_components/tuiss2ha/hub.py
+++ b/custom_components/tuiss2ha/hub.py
@@ -1000,6 +1000,7 @@ class TuissBlind:
                 self._last_battery_check = dt_util.now()
             except Exception:
                 self._last_battery_check = None
+            self.publish_updates()  # Notify sensors of battery check update
             self._stopped_event.set()
 
     async def position_callback(self, sender: BleakGATTCharacteristic, data: bytearray):

--- a/custom_components/tuiss2ha/select.py
+++ b/custom_components/tuiss2ha/select.py
@@ -33,9 +33,11 @@ async def async_setup_entry(
 class TuissPresetSelect(SelectEntity):
     """Dropdown of saved position presets for a Tuiss blind.
 
-    Picking an option calls the cover's set_cover_position service with the
-    stored value. The list of options is derived from blind.presets so it
-    stays in sync after save_preset / delete_preset service calls.
+    The selected option is *derived* from the live cover position rather
+    than stored: any preset whose value matches the current position is
+    shown as selected, and the dropdown clears as soon as the blind is
+    moved away. This keeps the entity from claiming the blind is at
+    "Movie" when the user has manually slid it elsewhere.
     """
 
     _attr_has_entity_name = True
@@ -53,7 +55,6 @@ class TuissPresetSelect(SelectEntity):
             manufacturer=self.blind.hub.manufacturer,
             model=self.blind.model,
         )
-        self._attr_current_option = None
 
     @property
     def options(self) -> list[str]:
@@ -64,6 +65,27 @@ class TuissPresetSelect(SelectEntity):
     def available(self) -> bool:
         """Available only when at least one preset is defined."""
         return bool(self.blind.presets)
+
+    @property
+    def current_option(self) -> str | None:
+        """Match the live cover position to a preset, else ``None``.
+
+        Recomputed every read so the dropdown reflects reality:
+        - Manual cover moves clear the selection.
+        - Re-arriving at a preset position re-selects it automatically.
+        - When two presets share a value, the alphabetically-first
+          name wins so the result is stable.
+        - Float positions are rounded before comparing so the entity
+          doesn't flicker on intermediate readings.
+        """
+        pos = self.blind._current_cover_position
+        if pos is None:
+            return None
+        target = int(round(pos))
+        for name in sorted(self.blind.presets):
+            if self.blind.presets[name] == target:
+                return name
+        return None
 
     async def async_select_option(self, option: str) -> None:
         """Apply the chosen preset by moving the cover to its position."""
@@ -97,11 +119,12 @@ class TuissPresetSelect(SelectEntity):
             {"entity_id": cover_entity_id, "position": position},
             blocking=False,
         )
-        self._attr_current_option = option
-        self.async_write_ha_state()
+        # No need to set _attr_current_option — current_option is
+        # derived from the live position, which the cover will publish
+        # via publish_updates() once the move starts.
 
     async def async_added_to_hass(self) -> None:
-        """Register callbacks so the dropdown refreshes on preset changes."""
+        """Register callbacks so the dropdown refreshes on state changes."""
         self.blind.register_callback(self._handle_update)
 
     async def async_will_remove_from_hass(self) -> None:
@@ -110,8 +133,5 @@ class TuissPresetSelect(SelectEntity):
 
     @callback
     def _handle_update(self) -> None:
-        """Refresh entity state when presets change."""
-        # Clear current_option if the previously selected preset was removed
-        if self._attr_current_option and self._attr_current_option not in self.blind.presets:
-            self._attr_current_option = None
+        """Refresh entity state when presets or position change."""
         self.async_write_ha_state()

--- a/custom_components/tuiss2ha/select.py
+++ b/custom_components/tuiss2ha/select.py
@@ -1,0 +1,117 @@
+"""Position preset select entity for Tuiss2HA."""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.select import SelectEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .hub import Hub, TuissBlind
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the Tuiss select entities (one preset selector per blind)."""
+    hub: Hub = hass.data[DOMAIN][config_entry.entry_id]
+    async_add_entities(
+        [TuissPresetSelect(blind) for blind in hub.blinds]
+    )
+
+
+class TuissPresetSelect(SelectEntity):
+    """Dropdown of saved position presets for a Tuiss blind.
+
+    Picking an option calls the cover's set_cover_position service with the
+    stored value. The list of options is derived from blind.presets so it
+    stays in sync after save_preset / delete_preset service calls.
+    """
+
+    _attr_has_entity_name = True
+    _attr_icon = "mdi:bookmark-multiple"
+    should_poll = False
+
+    def __init__(self, blind: TuissBlind) -> None:
+        """Initialize the select entity."""
+        self.blind = blind
+        self._attr_unique_id = f"{self.blind.blind_id}_preset_select"
+        self._attr_name = "Preset"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, self.blind.blind_id)},
+            name=self.blind.name,
+            manufacturer=self.blind.hub.manufacturer,
+            model=self.blind.model,
+        )
+        self._attr_current_option = None
+
+    @property
+    def options(self) -> list[str]:
+        """Return preset names sorted alphabetically for stable display."""
+        return sorted(self.blind.presets.keys())
+
+    @property
+    def available(self) -> bool:
+        """Available only when at least one preset is defined."""
+        return bool(self.blind.presets)
+
+    async def async_select_option(self, option: str) -> None:
+        """Apply the chosen preset by moving the cover to its position."""
+        if option not in self.blind.presets:
+            _LOGGER.warning(
+                "%s: Preset %r not found; available: %s",
+                self.blind.name, option, list(self.blind.presets),
+            )
+            return
+        position = self.blind.presets[option]
+        _LOGGER.info(
+            "%s: Applying preset %r -> position %s%%",
+            self.blind.name, option, position,
+        )
+
+        ent_reg = er.async_get(self.hass)
+        cover_unique_id = f"{self.blind.blind_id}_cover"
+        cover_entity_id = ent_reg.async_get_entity_id(
+            Platform.COVER, DOMAIN, cover_unique_id
+        )
+        if not cover_entity_id:
+            _LOGGER.warning(
+                "%s: Could not find cover entity for preset %r",
+                self.blind.name, option,
+            )
+            return
+
+        await self.hass.services.async_call(
+            "cover",
+            "set_cover_position",
+            {"entity_id": cover_entity_id, "position": position},
+            blocking=False,
+        )
+        self._attr_current_option = option
+        self.async_write_ha_state()
+
+    async def async_added_to_hass(self) -> None:
+        """Register callbacks so the dropdown refreshes on preset changes."""
+        self.blind.register_callback(self._handle_update)
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Remove callbacks."""
+        self.blind.remove_callback(self._handle_update)
+
+    @callback
+    def _handle_update(self) -> None:
+        """Refresh entity state when presets change."""
+        # Clear current_option if the previously selected preset was removed
+        if self._attr_current_option and self._attr_current_option not in self.blind.presets:
+            self._attr_current_option = None
+        self.async_write_ha_state()

--- a/custom_components/tuiss2ha/sensor.py
+++ b/custom_components/tuiss2ha/sensor.py
@@ -568,24 +568,32 @@ class TuissLastConnectionErrorSensor(SensorEntity):
 
 
 class TuissBatteryLevelRawSensor(SensorEntity):
-    """Tuiss Raw Battery Level Sensor.
+    """Tuiss raw battery reading.
 
-    Exposes the integer battery reading reported by the blind firmware
-    in the long-form battery response. Scale is currently unknown so
-    the value is published without a unit. Useful for collecting
-    calibration data toward a future percentage sensor.
+    Surfaces the integer reading the blind firmware sends after its
+    status nibble. The encoding is currently UNKNOWN — sample values
+    range across orders of magnitude (e.g. 1000 and 59492) so we do
+    not publish a unit and the value should be treated as opaque
+    until calibration data is available.
+
+    The full payload bytes after the 0xd2 status are exposed as the
+    ``payload_hex`` attribute so users and the maintainer can
+    reverse-engineer the encoding from real readings.
     """
 
     _attr_has_entity_name = True
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_icon = "mdi:battery-medium"
-    _attr_state_class = SensorStateClass.MEASUREMENT
+    # No state_class: classifying an unknown-scale value as a
+    # MEASUREMENT misleads HA's long-term-statistics machinery.
 
     def __init__(self, blind: TuissBlind) -> None:
         """Initialize the sensor."""
         self.blind = blind
+        # unique_id intentionally unchanged so existing entity IDs and
+        # automations created before the rename keep working.
         self._attr_unique_id = f"{self.blind.blind_id}_battery_level_raw"
-        self._attr_name = "Battery Level (raw)"
+        self._attr_name = "Battery Reading"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self.blind.blind_id)},
             name=self.blind.name,
@@ -596,13 +604,21 @@ class TuissBatteryLevelRawSensor(SensorEntity):
 
     @property
     def available(self) -> bool:
-        """Return True if a raw reading has been captured."""
+        """Return True if a reading has been captured."""
         return self.blind._battery_level_raw is not None
 
     @property
     def native_value(self) -> int | None:
         """Return the state of the sensor."""
         return self.blind._battery_level_raw
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Expose the full payload hex for calibration / debugging."""
+        return {
+            "payload_hex": self.blind._battery_payload_hex,
+            "note": "Encoding unknown — value is opaque. See payload_hex for raw bytes.",
+        }
 
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""

--- a/custom_components/tuiss2ha/sensor.py
+++ b/custom_components/tuiss2ha/sensor.py
@@ -69,6 +69,7 @@ async def async_setup_entry(
             TuissTraversalSpeedSensor(blind),
             TuissLastConnectionErrorSensor(blind),
             TuissBlindSpeedSensor(blind),
+            TuissBatteryLevelRawSensor(blind),
         ]
 
         async_add_entities(new_sensors)
@@ -563,4 +564,56 @@ class TuissLastConnectionErrorSensor(SensorEntity):
     def _handle_update(self) -> None:
         """Handle updated data from the hub."""
         self._attr_native_value = self.blind._last_connection_error or "None"
+        self.async_write_ha_state()
+
+
+class TuissBatteryLevelRawSensor(SensorEntity):
+    """Tuiss Raw Battery Level Sensor.
+
+    Exposes the integer battery reading reported by the blind firmware
+    in the long-form battery response. Scale is currently unknown so
+    the value is published without a unit. Useful for collecting
+    calibration data toward a future percentage sensor.
+    """
+
+    _attr_has_entity_name = True
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_icon = "mdi:battery-medium"
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
+    def __init__(self, blind: TuissBlind) -> None:
+        """Initialize the sensor."""
+        self.blind = blind
+        self._attr_unique_id = f"{self.blind.blind_id}_battery_level_raw"
+        self._attr_name = "Battery Level (raw)"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, self.blind.blind_id)},
+            name=self.blind.name,
+            manufacturer=self.blind.hub.manufacturer,
+            model=self.blind.model,
+        )
+        self._attr_native_value = self.blind._battery_level_raw
+
+    @property
+    def available(self) -> bool:
+        """Return True if a raw reading has been captured."""
+        return self.blind._battery_level_raw is not None
+
+    @property
+    def native_value(self) -> int | None:
+        """Return the state of the sensor."""
+        return self.blind._battery_level_raw
+
+    async def async_added_to_hass(self) -> None:
+        """Register callbacks."""
+        self.blind.register_callback(self._handle_update)
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Remove callbacks."""
+        self.blind.remove_callback(self._handle_update)
+
+    @callback
+    def _handle_update(self) -> None:
+        """Handle updated data from the hub."""
+        self._attr_native_value = self.blind._battery_level_raw
         self.async_write_ha_state()

--- a/custom_components/tuiss2ha/sensor.py
+++ b/custom_components/tuiss2ha/sensor.py
@@ -603,11 +603,6 @@ class TuissBatteryLevelRawSensor(SensorEntity):
         self._attr_native_value = self.blind._battery_level_raw
 
     @property
-    def available(self) -> bool:
-        """Return True if a reading has been captured."""
-        return self.blind._battery_level_raw is not None
-
-    @property
     def native_value(self) -> int | None:
         """Return the state of the sensor."""
         return self.blind._battery_level_raw

--- a/custom_components/tuiss2ha/services.yaml
+++ b/custom_components/tuiss2ha/services.yaml
@@ -124,3 +124,51 @@ delete_blind_timer:
           integration: tuiss2ha
           domain: sensor
           multiple: false
+
+save_preset:
+  # Save a named position preset for a blind. Existing names are overwritten.
+  # Stored in HA (separate from on-blind firmware timers).
+  fields:
+    entity_id:
+      required: true
+      selector:
+        entity:
+          integration: tuiss2ha
+    name:
+      required: true
+      selector:
+        text:
+    position:
+      required: true
+      selector:
+        number:
+          min: 0
+          max: 100
+          step: 1
+          mode: slider
+
+delete_preset:
+  # Remove a named position preset from a blind.
+  fields:
+    entity_id:
+      required: true
+      selector:
+        entity:
+          integration: tuiss2ha
+    name:
+      required: true
+      selector:
+        text:
+
+apply_preset:
+  # Move a blind to the position stored under the named preset.
+  fields:
+    entity_id:
+      required: true
+      selector:
+        entity:
+          integration: tuiss2ha
+    name:
+      required: true
+      selector:
+        text:

--- a/custom_components/tuiss2ha/services.yaml
+++ b/custom_components/tuiss2ha/services.yaml
@@ -147,6 +147,21 @@ save_preset:
           step: 1
           mode: slider
 
+save_current_position_as_preset:
+  # Save the blind's current position under a named preset. Useful when
+  # you don't know the exact percentage — move the blind where you want
+  # it, then call this with just a name.
+  fields:
+    entity_id:
+      required: true
+      selector:
+        entity:
+          integration: tuiss2ha
+    name:
+      required: true
+      selector:
+        text:
+
 delete_preset:
   # Remove a named position preset from a blind.
   fields:

--- a/custom_components/tuiss2ha/translations/de.json
+++ b/custom_components/tuiss2ha/translations/de.json
@@ -206,6 +206,20 @@
                 }
             }
         },
+        "save_current_position_as_preset": {
+            "name": "Aktuelle Position als Voreinstellung speichern",
+            "description": "Speichert die aktuelle Position der Jalousie unter einer benannten Voreinstellung. Bewegen Sie die Jalousie zuerst in die gewünschte Position — der Dienst speichert die zuletzt beobachtete Position, ohne nach einem Prozentsatz zu fragen.",
+            "fields": {
+                "entity_id": {
+                    "name": "Jalousie-Entität",
+                    "description": "Wählen Sie die Jalousie-Cover- oder Voreinstellungs-Entität aus."
+                },
+                "name": {
+                    "name": "Name der Voreinstellung",
+                    "description": "Kurze Bezeichnung der Voreinstellung (z. B. Lesen, Sonnenuntergang)."
+                }
+            }
+        },
         "delete_preset": {
             "name": "Positions-Voreinstellung löschen",
             "description": "Entfernt eine benannte Positions-Voreinstellung von einer Jalousie.",

--- a/custom_components/tuiss2ha/translations/de.json
+++ b/custom_components/tuiss2ha/translations/de.json
@@ -39,6 +39,7 @@
                 "data": {
                     "blind_restart_position": "Position des Rollos beim Neustart prüfen",
                     "blind_restart_attempts": "Wiederverbindungsversuche",
+                    "blind_operation_retry": "Wiederholungsversuche pro Aktion",
                     "blind_speed": "Wie schnell soll sich das Rollo in Position bewegen",
                     "blind_favorite_position": "Lieblingsposition",
                     "blind_battery_check_days": "Intervall der Batteriekontrolle (Tage)",
@@ -48,6 +49,7 @@
                 "data_description": {
                     "blind_restart_position": "Ruft die aktuelle Position des Rollos nach einem Neustart von Home Assistant ab. Nützlich, wenn Sie die Smartview-App oder eine Fernbedienung verwenden.",
                     "blind_restart_attempts": "Verbindungsversuche, die unternommen werden, bevor eine Zeitüberschreitung auftritt. Erhöhen Sie diesen Wert, wenn Sie feststellen, dass Anfragen verloren gehen. Hinweis: Die Entfernung zwischen Rollos und Bluetooth-Proxys/Dongles ist die Hauptursache für Verbindungsabbrüche.",
+                    "blind_operation_retry": "Anzahl der Wiederholungen einer Aktion (Öffnen, Schließen, Position setzen, Batteriestatus lesen) nach einem vorübergehenden Bluetooth-Fehler. 1 deaktiviert Wiederholungen; der Standard 2 bedeutet, dass ein einzelner Wiederholungsversuch durchgeführt wird, bevor der Fehler an Home Assistant gemeldet wird.",
                     "blind_favorite_position": "Die Position (in Prozent, 0=geschlossen, 100=geöffnet), zu der sich das Rollo bewegt, wenn die Taste 'Gehe zu Lieblingsposition' gedrückt wird.",
                     "blind_battery_check_days": "Anzahl der Tage zwischen automatischen Batteriekontrollen, wenn das Rollo bewegt wird. Auf 0 setzen, um automatische Prüfungen zu deaktivieren."
                 }

--- a/custom_components/tuiss2ha/translations/de.json
+++ b/custom_components/tuiss2ha/translations/de.json
@@ -38,8 +38,8 @@
                 "title": "Zusätzliche Optionen.",
                 "data": {
                     "blind_restart_position": "Position des Rollos beim Neustart prüfen",
-                    "blind_restart_attempts": "Wiederverbindungsversuche",
-                    "blind_operation_retry": "Wiederholungsversuche pro Aktion",
+                    "blind_restart_attempts": "Verbindungs-Wiederholungsversuche",
+                    "blind_operation_retry": "Befehls-Wiederholungsversuche",
                     "blind_speed": "Wie schnell soll sich das Rollo in Position bewegen",
                     "blind_favorite_position": "Lieblingsposition",
                     "blind_battery_check_days": "Intervall der Batteriekontrolle (Tage)",
@@ -48,8 +48,8 @@
                 },
                 "data_description": {
                     "blind_restart_position": "Ruft die aktuelle Position des Rollos nach einem Neustart von Home Assistant ab. Nützlich, wenn Sie die Smartview-App oder eine Fernbedienung verwenden.",
-                    "blind_restart_attempts": "Verbindungsversuche, die unternommen werden, bevor eine Zeitüberschreitung auftritt. Erhöhen Sie diesen Wert, wenn Sie feststellen, dass Anfragen verloren gehen. Hinweis: Die Entfernung zwischen Rollos und Bluetooth-Proxys/Dongles ist die Hauptursache für Verbindungsabbrüche.",
-                    "blind_operation_retry": "Anzahl der Wiederholungen einer Aktion (Öffnen, Schließen, Position setzen, Batteriestatus lesen) nach einem vorübergehenden Bluetooth-Fehler. 1 deaktiviert Wiederholungen; der Standard 2 bedeutet, dass ein einzelner Wiederholungsversuch durchgeführt wird, bevor der Fehler an Home Assistant gemeldet wird.",
+                    "blind_restart_attempts": "Anzahl der Wiederholungen für den Bluetooth-Verbindungsaufbau, wenn die Jalousie nicht auf den ursprünglichen Handshake antwortet. Erhöhen Sie diesen Wert, wenn die Verbindung zu Ihrem Proxy unzuverlässig ist.",
+                    "blind_operation_retry": "Anzahl der Wiederholungen eines vollständigen Befehls (öffnen, schließen, Position setzen, Batteriestatus lesen), wenn dieser nach erfolgreicher Verbindung fehlschlägt — zum Beispiel bei verlorener Benachrichtigung oder Schreib-Timeout. Jeder Versuch erzwingt eine neue Trennung und Wiederverbindung. 1 deaktiviert; 2 (Standard) führt einen einzelnen Wiederholungsversuch durch.",
                     "blind_favorite_position": "Die Position (in Prozent, 0=geschlossen, 100=geöffnet), zu der sich das Rollo bewegt, wenn die Taste 'Gehe zu Lieblingsposition' gedrückt wird.",
                     "blind_battery_check_days": "Anzahl der Tage zwischen automatischen Batteriekontrollen, wenn das Rollo bewegt wird. Auf 0 setzen, um automatische Prüfungen zu deaktivieren."
                 }

--- a/custom_components/tuiss2ha/translations/de.json
+++ b/custom_components/tuiss2ha/translations/de.json
@@ -185,6 +185,52 @@
                     "description": "Wählen Sie den Timer aus, den Sie entfernen möchten."
                 }
             }
+        },
+        "save_preset": {
+            "name": "Positions-Voreinstellung speichern",
+            "description": "Speichert eine benannte Positions-Voreinstellung für eine Jalousie. Bestehende Namen werden überschrieben. In Home Assistant gespeichert (nicht in der Jalousien-Firmware).",
+            "fields": {
+                "entity_id": {
+                    "name": "Jalousie-Entität",
+                    "description": "Wählen Sie die Jalousie-Cover- oder Voreinstellungs-Entität aus."
+                },
+                "name": {
+                    "name": "Name der Voreinstellung",
+                    "description": "Kurze Bezeichnung der Voreinstellung (z. B. Morgen, Film, Schlafen)."
+                },
+                "position": {
+                    "name": "Position",
+                    "description": "Position, zu der die Voreinstellung fährt (0 = geschlossen, 100 = offen)."
+                }
+            }
+        },
+        "delete_preset": {
+            "name": "Positions-Voreinstellung löschen",
+            "description": "Entfernt eine benannte Positions-Voreinstellung von einer Jalousie.",
+            "fields": {
+                "entity_id": {
+                    "name": "Jalousie-Entität",
+                    "description": "Wählen Sie die Jalousie-Cover- oder Voreinstellungs-Entität aus."
+                },
+                "name": {
+                    "name": "Name der Voreinstellung",
+                    "description": "Name der zu entfernenden Voreinstellung."
+                }
+            }
+        },
+        "apply_preset": {
+            "name": "Positions-Voreinstellung anwenden",
+            "description": "Bewegt eine Jalousie auf die in der Voreinstellung gespeicherte Position.",
+            "fields": {
+                "entity_id": {
+                    "name": "Jalousie-Entität",
+                    "description": "Wählen Sie die Jalousie-Cover- oder Voreinstellungs-Entität aus."
+                },
+                "name": {
+                    "name": "Name der Voreinstellung",
+                    "description": "Name der anzuwendenden Voreinstellung."
+                }
+            }
         }
     },
     "exceptions": {

--- a/custom_components/tuiss2ha/translations/en.json
+++ b/custom_components/tuiss2ha/translations/en.json
@@ -204,6 +204,20 @@
                 }
             }
         },
+        "save_current_position_as_preset": {
+            "name": "Save Current Position as Preset",
+            "description": "Save the blind's current position under a named preset. Move the blind to the desired position first — this service stores whatever position the integration last observed without asking for a percentage.",
+            "fields": {
+                "entity_id": {
+                    "name": "Blind Entity",
+                    "description": "Select the blind cover or its preset selector entity."
+                },
+                "name": {
+                    "name": "Preset Name",
+                    "description": "Short label for the preset (e.g. Reading, Sunset)."
+                }
+            }
+        },
         "delete_preset": {
             "name": "Delete Position Preset",
             "description": "Remove a named position preset from a blind.",

--- a/custom_components/tuiss2ha/translations/en.json
+++ b/custom_components/tuiss2ha/translations/en.json
@@ -183,6 +183,52 @@
                         "description": "Select the timer you wish to remove."
                     }
                 }
+        },
+        "save_preset": {
+            "name": "Save Position Preset",
+            "description": "Save a named position preset for a blind. Re-using an existing name overwrites it. Stored in Home Assistant (not on the blind firmware).",
+            "fields": {
+                "entity_id": {
+                    "name": "Blind Entity",
+                    "description": "Select the blind cover or its preset selector entity."
+                },
+                "name": {
+                    "name": "Preset Name",
+                    "description": "Short label for the preset (e.g. Morning, Movie, Sleep)."
+                },
+                "position": {
+                    "name": "Position",
+                    "description": "Position the preset moves to (0 = closed, 100 = open)."
+                }
+            }
+        },
+        "delete_preset": {
+            "name": "Delete Position Preset",
+            "description": "Remove a named position preset from a blind.",
+            "fields": {
+                "entity_id": {
+                    "name": "Blind Entity",
+                    "description": "Select the blind cover or its preset selector entity."
+                },
+                "name": {
+                    "name": "Preset Name",
+                    "description": "Name of the preset to remove."
+                }
+            }
+        },
+        "apply_preset": {
+            "name": "Apply Position Preset",
+            "description": "Move a blind to the position stored under the named preset.",
+            "fields": {
+                "entity_id": {
+                    "name": "Blind Entity",
+                    "description": "Select the blind cover or its preset selector entity."
+                },
+                "name": {
+                    "name": "Preset Name",
+                    "description": "Name of the preset to apply."
+                }
+            }
         }
     }
 ,

--- a/custom_components/tuiss2ha/translations/en.json
+++ b/custom_components/tuiss2ha/translations/en.json
@@ -38,8 +38,8 @@
                 "title": "Additional options",
                 "data": {
                     "blind_restart_position": "Check for blind position on restart",
-                    "blind_restart_attempts": "Reconnection attempts",
-                    "blind_operation_retry": "Operation retry attempts",
+                    "blind_restart_attempts": "Connection retry attempts",
+                    "blind_operation_retry": "Command retry attempts",
                     "blind_speed": "How fast should the blind move to position",
                     "blind_favorite_position": "Favorite Position",
                     "blind_battery_check_days": "Battery check interval (days)",
@@ -48,8 +48,8 @@
                 },
                 "data_description": {
                     "blind_restart_position": "Fetch the blinds current position following a Home Assistant restart. Useful if you use the Smartview app or a remote control.",
-                    "blind_restart_attempts": "Connection attempts that will be made before timing out. Increase this if you find that you are getting dropped requests. Note: the distance between blinds and Bluetooth proxies/dongles is the main cause for connection drop-offs.",
-                    "blind_operation_retry": "Number of times an operation (open, close, set position, read battery) is retried after a transient Bluetooth failure. 1 disables retries; the default of 2 means a single retry will be attempted before the error surfaces.",
+                    "blind_restart_attempts": "How many times to retry the Bluetooth connection itself when the blind doesn't respond to the initial handshake. Increase if the link to your proxy is unreliable.",
+                    "blind_operation_retry": "How many times to retry a whole command (open, close, set position, read battery) when it fails after the connection was already established — for example a dropped notification or a write timeout. Each retry forces a fresh disconnect and reconnect. 1 disables, 2 (default) does a single retry.",
                     "blind_favorite_position": "The position (in percent, 0=closed, 100=open) that the blind will move to when the 'Go to Favorite Position' button is pressed.",
                     "blind_battery_check_days": "The number of days between automatic battery checks (checks are made when the blind moves). Set to 0 to disable automatic checks."
                 }

--- a/custom_components/tuiss2ha/translations/en.json
+++ b/custom_components/tuiss2ha/translations/en.json
@@ -39,6 +39,7 @@
                 "data": {
                     "blind_restart_position": "Check for blind position on restart",
                     "blind_restart_attempts": "Reconnection attempts",
+                    "blind_operation_retry": "Operation retry attempts",
                     "blind_speed": "How fast should the blind move to position",
                     "blind_favorite_position": "Favorite Position",
                     "blind_battery_check_days": "Battery check interval (days)",
@@ -48,6 +49,7 @@
                 "data_description": {
                     "blind_restart_position": "Fetch the blinds current position following a Home Assistant restart. Useful if you use the Smartview app or a remote control.",
                     "blind_restart_attempts": "Connection attempts that will be made before timing out. Increase this if you find that you are getting dropped requests. Note: the distance between blinds and Bluetooth proxies/dongles is the main cause for connection drop-offs.",
+                    "blind_operation_retry": "Number of times an operation (open, close, set position, read battery) is retried after a transient Bluetooth failure. 1 disables retries; the default of 2 means a single retry will be attempted before the error surfaces.",
                     "blind_favorite_position": "The position (in percent, 0=closed, 100=open) that the blind will move to when the 'Go to Favorite Position' button is pressed.",
                     "blind_battery_check_days": "The number of days between automatic battery checks (checks are made when the blind moves). Set to 0 to disable automatic checks."
                 }

--- a/custom_components/tuiss2ha/translations/es.json
+++ b/custom_components/tuiss2ha/translations/es.json
@@ -38,8 +38,8 @@
                 "title": "Opciones adicionales.",
                 "data": {
                     "blind_restart_position": "Comprobar la posición de la persiana al reiniciar",
-                    "blind_restart_attempts": "Intentos de reconexión",
-                    "blind_operation_retry": "Reintentos por operación",
+                    "blind_restart_attempts": "Reintentos de conexión",
+                    "blind_operation_retry": "Reintentos por comando",
                     "blind_speed": "A qué velocidad debe moverse la persiana a la posición",
                     "blind_favorite_position": "Posición Favorita",
                     "blind_battery_check_days": "Intervalo de comprobación de batería (días)",
@@ -48,8 +48,8 @@
                 },
                 "data_description": {
                     "blind_restart_position": "Obtener la posición actual de las persianas después de un reinicio de Home Assistant. Útil si usas la aplicación Smartview o un mando a distancia.",
-                    "blind_restart_attempts": "Número de intentos de conexión que se realizarán antes de que se agote el tiempo de espera. Aumenta este valor si observas que se pierden solicitudes. Nota: la distancia entre las persianas y los proxies/dongles de Bluetooth es la causa principal de las caídas de conexión.",
-                    "blind_operation_retry": "Número de veces que se reintenta una operación (abrir, cerrar, fijar posición, leer batería) tras un fallo transitorio de Bluetooth. 1 desactiva los reintentos; el valor por defecto 2 hace que se realice un único reintento antes de que el error se notifique a Home Assistant.",
+                    "blind_restart_attempts": "Cuántas veces reintentar la conexión Bluetooth en sí cuando la persiana no responde al handshake inicial. Aumenta este valor si el enlace con tu proxy es poco fiable.",
+                    "blind_operation_retry": "Cuántas veces reintentar un comando completo (abrir, cerrar, fijar posición, leer batería) cuando falla después de establecer la conexión — por ejemplo una notificación perdida o un timeout de escritura. Cada reintento fuerza una desconexión y reconexión nuevas. 1 desactiva; 2 (predeterminado) realiza un único reintento.",
                     "blind_favorite_position": "La posición (en porcentaje, 0=cerrado, 100=abierto) a la que se moverá la persiana cuando se presione el botón 'Ir a la Posición Favorita'.",
                     "blind_battery_check_days": "Número de días entre comprobaciones automáticas de batería cuando la persiana se mueve. Establezca 0 para desactivar las comprobaciones automáticas."
                 }

--- a/custom_components/tuiss2ha/translations/es.json
+++ b/custom_components/tuiss2ha/translations/es.json
@@ -206,6 +206,20 @@
                 }
             }
         },
+        "save_current_position_as_preset": {
+            "name": "Guardar posición actual como preajuste",
+            "description": "Guarda la posición actual de la persiana con un nombre de preajuste. Mueve primero la persiana a la posición deseada — este servicio guarda la última posición observada por la integración sin pedir un porcentaje.",
+            "fields": {
+                "entity_id": {
+                    "name": "Entidad de persiana",
+                    "description": "Selecciona la entidad de la persiana o su selector de preajustes."
+                },
+                "name": {
+                    "name": "Nombre del preajuste",
+                    "description": "Etiqueta corta para el preajuste (ej. Lectura, Atardecer)."
+                }
+            }
+        },
         "delete_preset": {
             "name": "Eliminar preajuste de posición",
             "description": "Elimina un preajuste de posición con nombre de una persiana.",

--- a/custom_components/tuiss2ha/translations/es.json
+++ b/custom_components/tuiss2ha/translations/es.json
@@ -39,6 +39,7 @@
                 "data": {
                     "blind_restart_position": "Comprobar la posición de la persiana al reiniciar",
                     "blind_restart_attempts": "Intentos de reconexión",
+                    "blind_operation_retry": "Reintentos por operación",
                     "blind_speed": "A qué velocidad debe moverse la persiana a la posición",
                     "blind_favorite_position": "Posición Favorita",
                     "blind_battery_check_days": "Intervalo de comprobación de batería (días)",
@@ -48,6 +49,7 @@
                 "data_description": {
                     "blind_restart_position": "Obtener la posición actual de las persianas después de un reinicio de Home Assistant. Útil si usas la aplicación Smartview o un mando a distancia.",
                     "blind_restart_attempts": "Número de intentos de conexión que se realizarán antes de que se agote el tiempo de espera. Aumenta este valor si observas que se pierden solicitudes. Nota: la distancia entre las persianas y los proxies/dongles de Bluetooth es la causa principal de las caídas de conexión.",
+                    "blind_operation_retry": "Número de veces que se reintenta una operación (abrir, cerrar, fijar posición, leer batería) tras un fallo transitorio de Bluetooth. 1 desactiva los reintentos; el valor por defecto 2 hace que se realice un único reintento antes de que el error se notifique a Home Assistant.",
                     "blind_favorite_position": "La posición (en porcentaje, 0=cerrado, 100=abierto) a la que se moverá la persiana cuando se presione el botón 'Ir a la Posición Favorita'.",
                     "blind_battery_check_days": "Número de días entre comprobaciones automáticas de batería cuando la persiana se mueve. Establezca 0 para desactivar las comprobaciones automáticas."
                 }

--- a/custom_components/tuiss2ha/translations/es.json
+++ b/custom_components/tuiss2ha/translations/es.json
@@ -185,6 +185,52 @@
                     "description": "Selecciona el temporizador que deseas eliminar."
                 }
             }
+        },
+        "save_preset": {
+            "name": "Guardar preajuste de posición",
+            "description": "Guarda un preajuste de posición con nombre para una persiana. Los nombres existentes se sobrescriben. Se almacena en Home Assistant (no en el firmware de la persiana).",
+            "fields": {
+                "entity_id": {
+                    "name": "Entidad de persiana",
+                    "description": "Selecciona la entidad de la persiana o su selector de preajustes."
+                },
+                "name": {
+                    "name": "Nombre del preajuste",
+                    "description": "Etiqueta corta para el preajuste (ej. Mañana, Película, Dormir)."
+                },
+                "position": {
+                    "name": "Posición",
+                    "description": "Posición a la que se mueve el preajuste (0 = cerrada, 100 = abierta)."
+                }
+            }
+        },
+        "delete_preset": {
+            "name": "Eliminar preajuste de posición",
+            "description": "Elimina un preajuste de posición con nombre de una persiana.",
+            "fields": {
+                "entity_id": {
+                    "name": "Entidad de persiana",
+                    "description": "Selecciona la entidad de la persiana o su selector de preajustes."
+                },
+                "name": {
+                    "name": "Nombre del preajuste",
+                    "description": "Nombre del preajuste a eliminar."
+                }
+            }
+        },
+        "apply_preset": {
+            "name": "Aplicar preajuste de posición",
+            "description": "Mueve una persiana a la posición guardada bajo el preajuste con nombre.",
+            "fields": {
+                "entity_id": {
+                    "name": "Entidad de persiana",
+                    "description": "Selecciona la entidad de la persiana o su selector de preajustes."
+                },
+                "name": {
+                    "name": "Nombre del preajuste",
+                    "description": "Nombre del preajuste a aplicar."
+                }
+            }
         }
     },
     "exceptions": {

--- a/custom_components/tuiss2ha/translations/fr.json
+++ b/custom_components/tuiss2ha/translations/fr.json
@@ -39,6 +39,7 @@
                 "data": {
                     "blind_restart_position": "Vérifier la position du store au redémarrage",
                     "blind_restart_attempts": "Tentatives de reconnexion",
+                    "blind_operation_retry": "Nouvelles tentatives par opération",
                     "blind_speed": "À quelle vitesse le store doit-il se déplacer en position",
                     "blind_favorite_position": "Position Favorite",
                     "blind_battery_check_days": "Intervalle de vérification de la batterie (jours)",
@@ -48,6 +49,7 @@
                 "data_description": {
                     "blind_restart_position": "Récupérer la position actuelle des stores après un redémarrage de Home Assistant. Utile si vous utilisez l'application Smartview ou une télécommande.",
                     "blind_restart_attempts": "Nombre de tentatives de connexion qui seront effectuées avant l'expiration du délai. Augmentez cette valeur si vous constatez que vous recevez des demandes abandonnées. Remarque : la distance entre les stores et les proxys/dongles Bluetooth est la principale cause des pertes de connexion.",
+                    "blind_operation_retry": "Nombre de tentatives supplémentaires pour une opération (ouverture, fermeture, mise en position, lecture de la batterie) après un échec Bluetooth transitoire. 1 désactive les nouvelles tentatives ; la valeur par défaut de 2 effectue une seule nouvelle tentative avant que l'erreur ne soit remontée à Home Assistant.",
                     "blind_favorite_position": "La position (en pourcentage, 0=fermé, 100=ouvert) à laquelle le store se déplacera lorsque le bouton 'Aller à la Position Favorite' sera enfoncé.",
                     "blind_battery_check_days": "Nombre de jours entre les vérifications automatiques de la batterie lorsque le store se déplace. Réglez sur 0 pour désactiver les vérifications automatiques."
                 }

--- a/custom_components/tuiss2ha/translations/fr.json
+++ b/custom_components/tuiss2ha/translations/fr.json
@@ -38,8 +38,8 @@
                 "title": "Options supplémentaires.",
                 "data": {
                     "blind_restart_position": "Vérifier la position du store au redémarrage",
-                    "blind_restart_attempts": "Tentatives de reconnexion",
-                    "blind_operation_retry": "Nouvelles tentatives par opération",
+                    "blind_restart_attempts": "Nouvelles tentatives de connexion",
+                    "blind_operation_retry": "Nouvelles tentatives par commande",
                     "blind_speed": "À quelle vitesse le store doit-il se déplacer en position",
                     "blind_favorite_position": "Position Favorite",
                     "blind_battery_check_days": "Intervalle de vérification de la batterie (jours)",
@@ -48,8 +48,8 @@
                 },
                 "data_description": {
                     "blind_restart_position": "Récupérer la position actuelle des stores après un redémarrage de Home Assistant. Utile si vous utilisez l'application Smartview ou une télécommande.",
-                    "blind_restart_attempts": "Nombre de tentatives de connexion qui seront effectuées avant l'expiration du délai. Augmentez cette valeur si vous constatez que vous recevez des demandes abandonnées. Remarque : la distance entre les stores et les proxys/dongles Bluetooth est la principale cause des pertes de connexion.",
-                    "blind_operation_retry": "Nombre de tentatives supplémentaires pour une opération (ouverture, fermeture, mise en position, lecture de la batterie) après un échec Bluetooth transitoire. 1 désactive les nouvelles tentatives ; la valeur par défaut de 2 effectue une seule nouvelle tentative avant que l'erreur ne soit remontée à Home Assistant.",
+                    "blind_restart_attempts": "Nombre de tentatives pour la connexion Bluetooth elle-même lorsque le store ne répond pas au handshake initial. Augmentez si la liaison avec votre proxy est peu fiable.",
+                    "blind_operation_retry": "Nombre de tentatives pour une commande complète (ouverture, fermeture, mise en position, lecture de la batterie) qui échoue après que la connexion a été établie — par exemple une notification perdue ou un timeout d'écriture. Chaque tentative force une déconnexion et une reconnexion. 1 désactive ; 2 (par défaut) effectue une seule nouvelle tentative.",
                     "blind_favorite_position": "La position (en pourcentage, 0=fermé, 100=ouvert) à laquelle le store se déplacera lorsque le bouton 'Aller à la Position Favorite' sera enfoncé.",
                     "blind_battery_check_days": "Nombre de jours entre les vérifications automatiques de la batterie lorsque le store se déplace. Réglez sur 0 pour désactiver les vérifications automatiques."
                 }

--- a/custom_components/tuiss2ha/translations/fr.json
+++ b/custom_components/tuiss2ha/translations/fr.json
@@ -206,6 +206,20 @@
                 }
             }
         },
+        "save_current_position_as_preset": {
+            "name": "Enregistrer la position actuelle comme préréglage",
+            "description": "Enregistre la position actuelle du store sous un préréglage nommé. Déplacez d'abord le store à la position souhaitée — ce service enregistre la dernière position observée par l'intégration sans demander de pourcentage.",
+            "fields": {
+                "entity_id": {
+                    "name": "Entité du store",
+                    "description": "Sélectionnez l'entité du store ou son sélecteur de préréglages."
+                },
+                "name": {
+                    "name": "Nom du préréglage",
+                    "description": "Étiquette courte pour le préréglage (ex. Lecture, Coucher de soleil)."
+                }
+            }
+        },
         "delete_preset": {
             "name": "Supprimer le préréglage de position",
             "description": "Supprime un préréglage de position nommé d'un store.",

--- a/custom_components/tuiss2ha/translations/fr.json
+++ b/custom_components/tuiss2ha/translations/fr.json
@@ -185,6 +185,52 @@
                     "description": "Sélectionnez le minuteur que vous souhaitez supprimer."
                 }
             }
+        },
+        "save_preset": {
+            "name": "Enregistrer le préréglage de position",
+            "description": "Enregistre un préréglage de position nommé pour un store. Les noms existants sont écrasés. Stocké dans Home Assistant (pas dans le firmware du store).",
+            "fields": {
+                "entity_id": {
+                    "name": "Entité du store",
+                    "description": "Sélectionnez l'entité du store ou son sélecteur de préréglages."
+                },
+                "name": {
+                    "name": "Nom du préréglage",
+                    "description": "Étiquette courte pour le préréglage (ex. Matin, Film, Sommeil)."
+                },
+                "position": {
+                    "name": "Position",
+                    "description": "Position à laquelle le préréglage déplace le store (0 = fermé, 100 = ouvert)."
+                }
+            }
+        },
+        "delete_preset": {
+            "name": "Supprimer le préréglage de position",
+            "description": "Supprime un préréglage de position nommé d'un store.",
+            "fields": {
+                "entity_id": {
+                    "name": "Entité du store",
+                    "description": "Sélectionnez l'entité du store ou son sélecteur de préréglages."
+                },
+                "name": {
+                    "name": "Nom du préréglage",
+                    "description": "Nom du préréglage à supprimer."
+                }
+            }
+        },
+        "apply_preset": {
+            "name": "Appliquer le préréglage de position",
+            "description": "Déplace un store à la position enregistrée sous le préréglage nommé.",
+            "fields": {
+                "entity_id": {
+                    "name": "Entité du store",
+                    "description": "Sélectionnez l'entité du store ou son sélecteur de préréglages."
+                },
+                "name": {
+                    "name": "Nom du préréglage",
+                    "description": "Nom du préréglage à appliquer."
+                }
+            }
         }
     },
     "exceptions": {

--- a/custom_components/tuiss2ha/translations/it.json
+++ b/custom_components/tuiss2ha/translations/it.json
@@ -39,6 +39,7 @@
                 "data": {
                     "blind_restart_position": "Controlla la posizione della tenda al riavvio",
                     "blind_restart_attempts": "Tentativi di riconnessione",
+                    "blind_operation_retry": "Tentativi di ripetizione per operazione",
                     "blind_speed": "A che velocità la tenda dovrebbe spostarsi in posizione",
                     "blind_favorite_position": "Posizione Preferita",
                     "blind_battery_check_days": "Intervallo controllo batteria (giorni)",
@@ -48,6 +49,7 @@
                 "data_description": {
                     "blind_restart_position": "Recupera la posizione corrente delle tende dopo un riavvio di Home Assistant. Utile se usi l'app Smartview o un telecomando.",
                     "blind_restart_attempts": "Numero di tentativi di connessione che verranno effettuati prima del timeout. Aumenta questo valore se noti che le richieste vengono interrotte. Nota: la distanza tra le tende e i proxy/dongle Bluetooth è la causa principale delle interruzioni di connessione.",
+                    "blind_operation_retry": "Numero di volte in cui un'operazione (apertura, chiusura, impostazione posizione, lettura batteria) viene ripetuta dopo un guasto Bluetooth transitorio. 1 disabilita i tentativi; il valore predefinito 2 esegue un singolo nuovo tentativo prima che l'errore venga segnalato a Home Assistant.",
                     "blind_favorite_position": "La posizione (in percentuale, 0=chiuso, 100=aperto) in cui si sposterà la tenda quando viene premuto il pulsante 'Vai alla Posizione Preferita'.",
                     "blind_battery_check_days": "Numero di giorni tra i controlli automatici della batteria quando la tenda si sposta. Impostare 0 per disabilitare i controlli automatici."
                 }

--- a/custom_components/tuiss2ha/translations/it.json
+++ b/custom_components/tuiss2ha/translations/it.json
@@ -39,7 +39,7 @@
                 "data": {
                     "blind_restart_position": "Controlla la posizione della tenda al riavvio",
                     "blind_restart_attempts": "Tentativi di riconnessione",
-                    "blind_operation_retry": "Tentativi di ripetizione per operazione",
+                    "blind_operation_retry": "Tentativi per comando",
                     "blind_speed": "A che velocità la tenda dovrebbe spostarsi in posizione",
                     "blind_favorite_position": "Posizione Preferita",
                     "blind_battery_check_days": "Intervallo controllo batteria (giorni)",
@@ -48,8 +48,8 @@
                 },
                 "data_description": {
                     "blind_restart_position": "Recupera la posizione corrente delle tende dopo un riavvio di Home Assistant. Utile se usi l'app Smartview o un telecomando.",
-                    "blind_restart_attempts": "Numero di tentativi di connessione che verranno effettuati prima del timeout. Aumenta questo valore se noti che le richieste vengono interrotte. Nota: la distanza tra le tende e i proxy/dongle Bluetooth è la causa principale delle interruzioni di connessione.",
-                    "blind_operation_retry": "Numero di volte in cui un'operazione (apertura, chiusura, impostazione posizione, lettura batteria) viene ripetuta dopo un guasto Bluetooth transitorio. 1 disabilita i tentativi; il valore predefinito 2 esegue un singolo nuovo tentativo prima che l'errore venga segnalato a Home Assistant.",
+                    "blind_restart_attempts": "Quante volte riprovare la connessione Bluetooth in sé quando la tenda non risponde all'handshake iniziale. Aumenta se il collegamento al tuo proxy è poco affidabile.",
+                    "blind_operation_retry": "Quante volte riprovare un comando completo (apertura, chiusura, impostazione posizione, lettura batteria) quando fallisce dopo che la connessione era già stabilita — ad esempio una notifica persa o un timeout di scrittura. Ogni tentativo forza una nuova disconnessione e riconnessione. 1 disabilita; 2 (predefinito) esegue un solo nuovo tentativo.",
                     "blind_favorite_position": "La posizione (in percentuale, 0=chiuso, 100=aperto) in cui si sposterà la tenda quando viene premuto il pulsante 'Vai alla Posizione Preferita'.",
                     "blind_battery_check_days": "Numero di giorni tra i controlli automatici della batteria quando la tenda si sposta. Impostare 0 per disabilitare i controlli automatici."
                 }

--- a/custom_components/tuiss2ha/translations/it.json
+++ b/custom_components/tuiss2ha/translations/it.json
@@ -185,6 +185,52 @@
                     "description": "Seleziona il timer che desideri rimuovere."
                 }
             }
+        },
+        "save_preset": {
+            "name": "Salva preset di posizione",
+            "description": "Salva un preset di posizione con nome per una tenda. I nomi esistenti vengono sovrascritti. Memorizzato in Home Assistant (non nel firmware della tenda).",
+            "fields": {
+                "entity_id": {
+                    "name": "Entità tenda",
+                    "description": "Seleziona l'entità della tenda o il suo selettore di preset."
+                },
+                "name": {
+                    "name": "Nome del preset",
+                    "description": "Etichetta breve per il preset (es. Mattino, Film, Notte)."
+                },
+                "position": {
+                    "name": "Posizione",
+                    "description": "Posizione a cui il preset sposta la tenda (0 = chiusa, 100 = aperta)."
+                }
+            }
+        },
+        "delete_preset": {
+            "name": "Elimina preset di posizione",
+            "description": "Rimuove un preset di posizione con nome da una tenda.",
+            "fields": {
+                "entity_id": {
+                    "name": "Entità tenda",
+                    "description": "Seleziona l'entità della tenda o il suo selettore di preset."
+                },
+                "name": {
+                    "name": "Nome del preset",
+                    "description": "Nome del preset da rimuovere."
+                }
+            }
+        },
+        "apply_preset": {
+            "name": "Applica preset di posizione",
+            "description": "Sposta una tenda alla posizione salvata nel preset con il nome indicato.",
+            "fields": {
+                "entity_id": {
+                    "name": "Entità tenda",
+                    "description": "Seleziona l'entità della tenda o il suo selettore di preset."
+                },
+                "name": {
+                    "name": "Nome del preset",
+                    "description": "Nome del preset da applicare."
+                }
+            }
         }
     },
     "exceptions": {

--- a/custom_components/tuiss2ha/translations/it.json
+++ b/custom_components/tuiss2ha/translations/it.json
@@ -206,6 +206,20 @@
                 }
             }
         },
+        "save_current_position_as_preset": {
+            "name": "Salva posizione attuale come preset",
+            "description": "Salva la posizione attuale della tenda con un nome di preset. Sposta prima la tenda nella posizione desiderata — questo servizio memorizza l'ultima posizione osservata dall'integrazione senza chiedere una percentuale.",
+            "fields": {
+                "entity_id": {
+                    "name": "Entità tenda",
+                    "description": "Seleziona l'entità della tenda o il suo selettore di preset."
+                },
+                "name": {
+                    "name": "Nome del preset",
+                    "description": "Etichetta breve per il preset (es. Lettura, Tramonto)."
+                }
+            }
+        },
         "delete_preset": {
             "name": "Elimina preset di posizione",
             "description": "Rimuove un preset di posizione con nome da una tenda.",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,6 +45,7 @@ def pytest_sessionstart(session):
         "SensorEntity": type("SensorEntity", (MockEntity,), {}),
         "BinarySensorEntity": type("BinarySensorEntity", (MockEntity,), {}),
         "ButtonEntity": type("ButtonEntity", (MockEntity,), {}),
+        "SelectEntity": type("SelectEntity", (MockEntity,), {}),
     }
 
     # Create a mock for the 'homeassistant' root module
@@ -91,6 +92,7 @@ def pytest_sessionstart(session):
     sys.modules["homeassistant.components.binary_sensor"] = MagicMock(**mock_entity_classes)
     sys.modules["homeassistant.components.button"] = MagicMock(**mock_entity_classes)
     sys.modules["homeassistant.components.cover"] = MagicMock(**mock_entity_classes)
+    sys.modules["homeassistant.components.select"] = MagicMock(**mock_entity_classes)
 
     # Mock other required modules that don't contain entity base classes
     import types

--- a/tests/test_battery_level.py
+++ b/tests/test_battery_level.py
@@ -1,0 +1,90 @@
+"""Tests for the raw battery level capture in battery_callback."""
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.tuiss2ha.hub import TuissBlind
+
+
+def _make_blind(mock_hass) -> TuissBlind:
+    """Build a TuissBlind with bluetooth discovery patched."""
+    fake_device = MagicMock()
+    fake_device.name = "TB-01"
+    with patch(
+        "custom_components.tuiss2ha.hub.bluetooth.async_ble_device_from_address",
+        return_value=fake_device,
+    ):
+        hub = MagicMock()
+        hub._hass = mock_hass
+        return TuissBlind("AA:BB:CC:DD:EE:FF", "Test", hub)
+
+
+@pytest.mark.asyncio
+async def test_battery_level_raw_parsed_from_long_frame(mock_hass):
+    """Long-form response should populate _battery_level_raw with LE u16 from bytes [6..8]."""
+    tb = _make_blind(mock_hass)
+    # Avoid touching BLE / ha state during the callback.
+    tb.disconnect = AsyncMock()
+    tb.publish_updates = MagicMock()
+
+    # ff 01 02 03 d2 02 e8 03  -> raw value = 0x03e8 = 1000
+    data = bytearray.fromhex("ff010203d202e803")
+    sender = MagicMock()
+
+    await tb.battery_callback(sender, data)
+
+    assert tb._battery_level_raw == 1000
+    assert tb._battery_status is False  # decimals[5]=2 < 10 -> good
+    tb.publish_updates.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_battery_level_raw_none_for_short_frame(mock_hass):
+    """Low-battery (length 7) response should not populate _battery_level_raw."""
+    tb = _make_blind(mock_hass)
+    tb.disconnect = AsyncMock()
+    tb.publish_updates = MagicMock()
+
+    # ff 01 02 03 d2 00 00  -> 7 bytes, len==7 branch -> low battery, no raw level
+    data = bytearray.fromhex("ff010203d20000")
+    sender = MagicMock()
+
+    await tb.battery_callback(sender, data)
+
+    assert tb._battery_level_raw is None
+    assert tb._battery_status is True  # len == 7 -> low
+    tb.publish_updates.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_battery_level_raw_overwritten_on_subsequent_read(mock_hass):
+    """A later good frame should overwrite a previous reading."""
+    tb = _make_blind(mock_hass)
+    tb.disconnect = AsyncMock()
+    tb.publish_updates = MagicMock()
+
+    # First reading: 1000
+    await tb.battery_callback(MagicMock(), bytearray.fromhex("ff010203d202e803"))
+    assert tb._battery_level_raw == 1000
+
+    # Second reading: 0x01f4 = 500
+    await tb.battery_callback(MagicMock(), bytearray.fromhex("ff010203d202f401"))
+    assert tb._battery_level_raw == 500
+
+
+@pytest.mark.asyncio
+async def test_battery_level_raw_unset_when_invalid_header(mock_hass):
+    """If decimals[4] != 0xd2 the callback exits without touching state."""
+    tb = _make_blind(mock_hass)
+    tb.disconnect = AsyncMock()
+    tb.publish_updates = MagicMock()
+
+    # Pre-seed a reading; an invalid frame must not clobber it.
+    tb._battery_level_raw = 999
+
+    # Invalid header byte at position 4
+    data = bytearray.fromhex("ff01020399ffffff")
+    await tb.battery_callback(MagicMock(), data)
+
+    assert tb._battery_level_raw == 999
+    tb.publish_updates.assert_not_called()

--- a/tests/test_battery_level.py
+++ b/tests/test_battery_level.py
@@ -21,7 +21,7 @@ def _make_blind(mock_hass) -> TuissBlind:
 
 @pytest.mark.asyncio
 async def test_battery_level_raw_parsed_from_long_frame(mock_hass):
-    """Long-form response should populate _battery_level_raw with LE u16 from bytes [6..8]."""
+    """Long-form response populates raw reading and payload hex."""
     tb = _make_blind(mock_hass)
     # Avoid touching BLE / ha state during the callback.
     tb.disconnect = AsyncMock()
@@ -34,13 +34,15 @@ async def test_battery_level_raw_parsed_from_long_frame(mock_hass):
     await tb.battery_callback(sender, data)
 
     assert tb._battery_level_raw == 1000
+    # payload hex captures every byte after the 0xd2 status nibble.
+    assert tb._battery_payload_hex == "02e803"
     assert tb._battery_status is False  # decimals[5]=2 < 10 -> good
     tb.publish_updates.assert_called_once()
 
 
 @pytest.mark.asyncio
 async def test_battery_level_raw_none_for_short_frame(mock_hass):
-    """Low-battery (length 7) response should not populate _battery_level_raw."""
+    """Low-battery (length 7) response: no raw level, payload hex still set."""
     tb = _make_blind(mock_hass)
     tb.disconnect = AsyncMock()
     tb.publish_updates = MagicMock()
@@ -52,13 +54,15 @@ async def test_battery_level_raw_none_for_short_frame(mock_hass):
     await tb.battery_callback(sender, data)
 
     assert tb._battery_level_raw is None
+    # bytes after 0xd2 are still surfaced as hex even when too short for u16.
+    assert tb._battery_payload_hex == "0000"
     assert tb._battery_status is True  # len == 7 -> low
     tb.publish_updates.assert_called_once()
 
 
 @pytest.mark.asyncio
 async def test_battery_level_raw_overwritten_on_subsequent_read(mock_hass):
-    """A later good frame should overwrite a previous reading."""
+    """A later good frame should overwrite both reading and payload hex."""
     tb = _make_blind(mock_hass)
     tb.disconnect = AsyncMock()
     tb.publish_updates = MagicMock()
@@ -66,10 +70,12 @@ async def test_battery_level_raw_overwritten_on_subsequent_read(mock_hass):
     # First reading: 1000
     await tb.battery_callback(MagicMock(), bytearray.fromhex("ff010203d202e803"))
     assert tb._battery_level_raw == 1000
+    assert tb._battery_payload_hex == "02e803"
 
     # Second reading: 0x01f4 = 500
     await tb.battery_callback(MagicMock(), bytearray.fromhex("ff010203d202f401"))
     assert tb._battery_level_raw == 500
+    assert tb._battery_payload_hex == "02f401"
 
 
 @pytest.mark.asyncio
@@ -79,12 +85,31 @@ async def test_battery_level_raw_unset_when_invalid_header(mock_hass):
     tb.disconnect = AsyncMock()
     tb.publish_updates = MagicMock()
 
-    # Pre-seed a reading; an invalid frame must not clobber it.
+    # Pre-seed values; an invalid frame must not clobber them.
     tb._battery_level_raw = 999
+    tb._battery_payload_hex = "deadbeef"
 
     # Invalid header byte at position 4
     data = bytearray.fromhex("ff01020399ffffff")
     await tb.battery_callback(MagicMock(), data)
 
     assert tb._battery_level_raw == 999
+    assert tb._battery_payload_hex == "deadbeef"
     tb.publish_updates.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_battery_payload_hex_captures_extra_bytes(mock_hass):
+    """If the firmware returns more than 8 bytes, payload hex captures them all."""
+    tb = _make_blind(mock_hass)
+    tb.disconnect = AsyncMock()
+    tb.publish_updates = MagicMock()
+
+    # Long frame with extra trailing bytes — the LE u16 is still bytes[6..8]
+    # but the full tail must be exposed for calibration work.
+    # ff 01 02 03 d2 02 24 e8 ab cd  -> raw = 0xe824 = 59428, hex = 0224e8abcd
+    data = bytearray.fromhex("ff010203d20224e8abcd")
+    await tb.battery_callback(MagicMock(), data)
+
+    assert tb._battery_level_raw == 0xe824
+    assert tb._battery_payload_hex == "0224e8abcd"

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -167,3 +167,96 @@ async def test_save_current_handles_integer_position(mock_hass):
 
     assert result == 50
     assert tb.presets == {"Half": 50}
+
+
+def _make_select(mock_hass):
+    """Build a TuissPresetSelect bound to a fresh blind."""
+    from custom_components.tuiss2ha.select import TuissPresetSelect
+    tb = _make_blind(mock_hass)
+    return TuissPresetSelect(tb), tb
+
+
+def test_select_current_option_none_when_position_unknown(mock_hass):
+    """Position never read -> dropdown shows nothing selected."""
+    sel, tb = _make_select(mock_hass)
+    tb.presets = {"Movie": 30, "Morning": 100}
+    tb._current_cover_position = None
+
+    assert sel.current_option is None
+
+
+def test_select_current_option_matches_exact_position(mock_hass):
+    """Live position equal to a preset value -> that preset is selected."""
+    sel, tb = _make_select(mock_hass)
+    tb.presets = {"Movie": 30, "Morning": 100, "Sleep": 0}
+    tb._current_cover_position = 30
+
+    assert sel.current_option == "Movie"
+
+
+def test_select_current_option_none_when_no_match(mock_hass):
+    """Position between presets -> nothing selected."""
+    sel, tb = _make_select(mock_hass)
+    tb.presets = {"Movie": 30, "Morning": 100}
+    tb._current_cover_position = 55
+
+    assert sel.current_option is None
+
+
+def test_select_current_option_rounds_float(mock_hass):
+    """Float position is rounded before comparing — 99.7 matches 100."""
+    sel, tb = _make_select(mock_hass)
+    tb.presets = {"Morning": 100}
+    tb._current_cover_position = 99.7
+
+    assert sel.current_option == "Morning"
+
+
+def test_select_current_option_alphabetical_tiebreak(mock_hass):
+    """When two presets share a value, the alphabetically-first wins."""
+    sel, tb = _make_select(mock_hass)
+    tb.presets = {"Zeta": 50, "Alpha": 50, "Mid": 50}
+    tb._current_cover_position = 50
+
+    # sorted({"Zeta","Alpha","Mid"}) -> "Alpha","Mid","Zeta" -> first match Alpha
+    assert sel.current_option == "Alpha"
+
+
+def test_select_current_option_clears_after_manual_move(mock_hass):
+    """A manual move away from the preset clears the selection."""
+    sel, tb = _make_select(mock_hass)
+    tb.presets = {"Movie": 30}
+    tb._current_cover_position = 30
+    assert sel.current_option == "Movie"
+
+    # User manually drags blind to 70 — no service call, just position update
+    tb._current_cover_position = 70
+    assert sel.current_option is None
+
+
+def test_select_current_option_re_selects_on_return(mock_hass):
+    """Returning to a preset position re-selects it automatically."""
+    sel, tb = _make_select(mock_hass)
+    tb.presets = {"Reading": 42}
+    tb._current_cover_position = 100  # somewhere else
+    assert sel.current_option is None
+
+    # Move back to the preset value
+    tb._current_cover_position = 42
+    assert sel.current_option == "Reading"
+
+
+def test_select_options_sorted(mock_hass):
+    """Options list is alphabetically sorted for stable UI display."""
+    sel, tb = _make_select(mock_hass)
+    tb.presets = {"Zeta": 1, "Alpha": 2, "Mid": 3}
+
+    assert sel.options == ["Alpha", "Mid", "Zeta"]
+
+
+def test_select_unavailable_when_no_presets(mock_hass):
+    """The entity reports itself unavailable when no presets are defined."""
+    sel, tb = _make_select(mock_hass)
+    tb.presets = {}
+
+    assert sel.available is False

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -1,0 +1,103 @@
+"""Tests for the position presets feature: storage + select entity + services."""
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.tuiss2ha.hub import TuissBlind
+
+
+def _make_blind(mock_hass) -> TuissBlind:
+    """Build a TuissBlind with bluetooth discovery patched."""
+    fake_device = MagicMock()
+    fake_device.name = "TB-01"
+    with patch(
+        "custom_components.tuiss2ha.hub.bluetooth.async_ble_device_from_address",
+        return_value=fake_device,
+    ):
+        hub = MagicMock()
+        hub._hass = mock_hass
+        return TuissBlind("AA:BB:CC:DD:EE:FF", "Test", hub)
+
+
+@pytest.mark.asyncio
+async def test_async_load_presets_empty_when_store_empty(mock_hass):
+    """No stored data should leave presets as an empty dict."""
+    tb = _make_blind(mock_hass)
+    tb._presets_store = MagicMock()
+    tb._presets_store.async_load = AsyncMock(return_value=None)
+
+    await tb.async_load_presets()
+
+    assert tb.presets == {}
+
+
+@pytest.mark.asyncio
+async def test_async_load_presets_round_trips(mock_hass):
+    """Stored dict is loaded verbatim into blind.presets."""
+    tb = _make_blind(mock_hass)
+    tb._presets_store = MagicMock()
+    tb._presets_store.async_load = AsyncMock(
+        return_value={"Morning": 100, "Movie": 30, "Sleep": 0}
+    )
+
+    await tb.async_load_presets()
+
+    assert tb.presets == {"Morning": 100, "Movie": 30, "Sleep": 0}
+
+
+@pytest.mark.asyncio
+async def test_async_load_presets_drops_invalid_entries(mock_hass):
+    """Malformed entries are dropped without raising."""
+    tb = _make_blind(mock_hass)
+    tb._presets_store = MagicMock()
+    tb._presets_store.async_load = AsyncMock(
+        return_value={
+            "Good": 50,
+            "OutOfRange": 150,            # > 100 -> dropped
+            "Negative": -1,                # < 0 -> dropped
+            "BadType": "not-a-number",     # not coercible -> dropped
+            "": 25,                         # empty name -> dropped
+        }
+    )
+
+    await tb.async_load_presets()
+
+    assert tb.presets == {"Good": 50}
+
+
+@pytest.mark.asyncio
+async def test_async_save_presets_persists(mock_hass):
+    """Saving forwards the current presets dict to the store."""
+    tb = _make_blind(mock_hass)
+    tb._presets_store = MagicMock()
+    tb._presets_store.async_save = AsyncMock()
+    tb.presets = {"X": 10, "Y": 90}
+
+    await tb.async_save_presets()
+
+    tb._presets_store.async_save.assert_awaited_once_with({"X": 10, "Y": 90})
+
+
+@pytest.mark.asyncio
+async def test_async_load_presets_coerces_string_positions(mock_hass):
+    """Storage layer may give back strings; loader should coerce to int."""
+    tb = _make_blind(mock_hass)
+    tb._presets_store = MagicMock()
+    tb._presets_store.async_load = AsyncMock(return_value={"Morning": "75"})
+
+    await tb.async_load_presets()
+
+    assert tb.presets == {"Morning": 75}
+    assert isinstance(tb.presets["Morning"], int)
+
+
+@pytest.mark.asyncio
+async def test_async_load_presets_handles_non_dict_payload(mock_hass):
+    """A corrupt non-dict payload should reset to empty rather than crash."""
+    tb = _make_blind(mock_hass)
+    tb._presets_store = MagicMock()
+    tb._presets_store.async_load = AsyncMock(return_value=["unexpected", "list"])
+
+    await tb.async_load_presets()
+
+    assert tb.presets == {}

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -101,3 +101,69 @@ async def test_async_load_presets_handles_non_dict_payload(mock_hass):
     await tb.async_load_presets()
 
     assert tb.presets == {}
+
+
+@pytest.mark.asyncio
+async def test_save_current_stores_rounded_position(mock_hass):
+    """async_save_current_as_preset rounds the live position to int."""
+    tb = _make_blind(mock_hass)
+    tb._presets_store = MagicMock()
+    tb._presets_store.async_save = AsyncMock()
+    tb.publish_updates = MagicMock()
+    tb._current_cover_position = 42.7
+
+    result = await tb.async_save_current_as_preset("Reading")
+
+    assert result == 43
+    assert tb.presets == {"Reading": 43}
+    tb._presets_store.async_save.assert_awaited_once_with({"Reading": 43})
+    tb.publish_updates.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_save_current_returns_none_when_position_unknown(mock_hass):
+    """If the cover position has never been read, refuse and don't persist."""
+    tb = _make_blind(mock_hass)
+    tb._presets_store = MagicMock()
+    tb._presets_store.async_save = AsyncMock()
+    tb.publish_updates = MagicMock()
+    tb._current_cover_position = None
+
+    result = await tb.async_save_current_as_preset("Reading")
+
+    assert result is None
+    assert tb.presets == {}
+    tb._presets_store.async_save.assert_not_called()
+    tb.publish_updates.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_save_current_overwrites_existing_name(mock_hass):
+    """Re-using a preset name overwrites the old position."""
+    tb = _make_blind(mock_hass)
+    tb._presets_store = MagicMock()
+    tb._presets_store.async_save = AsyncMock()
+    tb.publish_updates = MagicMock()
+    tb.presets = {"Reading": 10}
+    tb._current_cover_position = 75
+
+    result = await tb.async_save_current_as_preset("Reading")
+
+    assert result == 75
+    assert tb.presets == {"Reading": 75}
+    tb._presets_store.async_save.assert_awaited_once_with({"Reading": 75})
+
+
+@pytest.mark.asyncio
+async def test_save_current_handles_integer_position(mock_hass):
+    """An integer position is stored as-is (round is a no-op)."""
+    tb = _make_blind(mock_hass)
+    tb._presets_store = MagicMock()
+    tb._presets_store.async_save = AsyncMock()
+    tb.publish_updates = MagicMock()
+    tb._current_cover_position = 50
+
+    result = await tb.async_save_current_as_preset("Half")
+
+    assert result == 50
+    assert tb.presets == {"Half": 50}

--- a/tests/test_retry_backoff.py
+++ b/tests/test_retry_backoff.py
@@ -1,0 +1,166 @@
+"""Tests for the auto-retry-with-backoff feature."""
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from bleak.exc import BleakError
+
+from custom_components.tuiss2ha.hub import TuissBlind
+from custom_components.tuiss2ha.const import (
+    BACKOFF_BASE_SECONDS,
+    BACKOFF_MAX_SECONDS,
+    DEFAULT_OPERATION_RETRY,
+    DeviceNotFound,
+    ConnectionTimeout,
+)
+
+
+def _make_blind(mock_hass) -> TuissBlind:
+    """Build a TuissBlind with bluetooth discovery patched."""
+    fake_device = MagicMock()
+    fake_device.name = "TB-01"
+    with patch(
+        "custom_components.tuiss2ha.hub.bluetooth.async_ble_device_from_address",
+        return_value=fake_device,
+    ):
+        hub = MagicMock()
+        hub._hass = mock_hass
+        return TuissBlind("AA:BB:CC:DD:EE:FF", "Test", hub)
+
+
+def test_backoff_delay_doubles_then_caps():
+    """Sequence is BASE, BASE*2, BASE*4, ... capped at MAX (jitter ignored)."""
+    # Force jitter to zero for deterministic comparison.
+    with patch("custom_components.tuiss2ha.hub.random.uniform", return_value=0.0):
+        delays = [TuissBlind._backoff_delay(n) for n in range(1, 8)]
+
+    assert delays[0] == BACKOFF_BASE_SECONDS                  # 1
+    assert delays[1] == BACKOFF_BASE_SECONDS * 2              # 2
+    assert delays[2] == BACKOFF_BASE_SECONDS * 4              # 4
+    assert delays[3] == BACKOFF_BASE_SECONDS * 8              # 8
+    assert delays[4] == BACKOFF_MAX_SECONDS                   # 16 capped
+    assert delays[5] == BACKOFF_MAX_SECONDS                   # still capped
+    assert delays[6] == BACKOFF_MAX_SECONDS                   # still capped
+
+
+def test_backoff_delay_adds_jitter_within_bound():
+    """Jitter must not exceed BACKOFF_JITTER_SECONDS."""
+    base = TuissBlind._backoff_delay(1)
+    assert BACKOFF_BASE_SECONDS <= base <= BACKOFF_BASE_SECONDS + 1.0  # generous slack
+
+
+@pytest.mark.asyncio
+async def test_retry_operation_returns_first_success(mock_hass):
+    """A successful first call returns immediately and is not retried."""
+    tb = _make_blind(mock_hass)
+    op = AsyncMock(return_value="ok")
+
+    result = await tb._retry_operation("test_op", op, max_attempts=3)
+
+    assert result == "ok"
+    assert op.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_retry_operation_recovers_on_second_attempt(mock_hass):
+    """A transient failure is followed by a reconnect and a successful retry."""
+    tb = _make_blind(mock_hass)
+    tb.disconnect = AsyncMock()
+
+    calls = {"n": 0}
+
+    async def flaky():
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise BleakError("transient")
+        return "second"
+
+    # Patch the inter-attempt sleep so the test runs fast.
+    with patch("custom_components.tuiss2ha.hub.asyncio.sleep", AsyncMock()):
+        result = await tb._retry_operation("test_op", flaky, max_attempts=3)
+
+    assert result == "second"
+    assert calls["n"] == 2
+    # disconnect must be called between attempts to drop the stale client
+    tb.disconnect.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_retry_operation_gives_up_after_max_attempts(mock_hass):
+    """Persistent transient errors raise after the configured number of tries."""
+    tb = _make_blind(mock_hass)
+    tb.disconnect = AsyncMock()
+
+    op = AsyncMock(side_effect=BleakError("never recovers"))
+
+    with patch("custom_components.tuiss2ha.hub.asyncio.sleep", AsyncMock()):
+        with pytest.raises(BleakError):
+            await tb._retry_operation("test_op", op, max_attempts=3)
+
+    assert op.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_retry_operation_does_not_retry_devicenotfound(mock_hass):
+    """DeviceNotFound is non-transient and must propagate immediately."""
+    tb = _make_blind(mock_hass)
+    tb.disconnect = AsyncMock()
+
+    op = AsyncMock(side_effect=DeviceNotFound("gone"))
+
+    with pytest.raises(DeviceNotFound):
+        await tb._retry_operation("test_op", op, max_attempts=5)
+
+    assert op.await_count == 1
+    tb.disconnect.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_retry_operation_uses_default_when_max_none(mock_hass):
+    """Falling back to the default operation-retry count when not specified."""
+    tb = _make_blind(mock_hass)
+    tb.disconnect = AsyncMock()
+    tb._operation_retry = None  # force default fallback
+
+    op = AsyncMock(side_effect=ConnectionTimeout("flaky"))
+
+    with patch("custom_components.tuiss2ha.hub.asyncio.sleep", AsyncMock()):
+        with pytest.raises(ConnectionTimeout):
+            await tb._retry_operation("test_op", op)
+
+    assert op.await_count == DEFAULT_OPERATION_RETRY
+
+
+@pytest.mark.asyncio
+async def test_retry_operation_clamps_max_attempts_to_one(mock_hass):
+    """max_attempts < 1 is normalised to 1 — never run zero times."""
+    tb = _make_blind(mock_hass)
+    tb.disconnect = AsyncMock()
+    op = AsyncMock(return_value="ok")
+
+    result = await tb._retry_operation("test_op", op, max_attempts=0)
+
+    assert result == "ok"
+    assert op.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_retry_operation_disconnect_failure_is_swallowed(mock_hass):
+    """If disconnect fails between attempts, the next retry still runs."""
+    tb = _make_blind(mock_hass)
+    tb.disconnect = AsyncMock(side_effect=RuntimeError("disconnect fail"))
+
+    calls = {"n": 0}
+
+    async def flaky():
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise BleakError("transient")
+        return "ok"
+
+    with patch("custom_components.tuiss2ha.hub.asyncio.sleep", AsyncMock()):
+        result = await tb._retry_operation("test_op", flaky, max_attempts=3)
+
+    assert result == "ok"
+    assert calls["n"] == 2


### PR DESCRIPTION
## What this adds

A few extras built on top of PR #123:

**Battery Reading sensor** — surfaces the extra battery info the blind already sends. The number's meaning isn't decoded yet, so the raw bytes are also exposed as an attribute to help figure it out later.

**Position presets (double-roll blinds)** — this one is specifically aimed at double-roll blinds (two layers of fabric on the same window). On these, the position percentage means very different things depending on what you want — around 50% only the front layer is partly open, at 80% the front is fully open and the back fabric starts to lift, at 30% nothing useful happens. Trying to remember "what number gets me the look I want" is awkward, and any time you tweak it you have to re-discover the right value. Presets fix this: save the position once with a name like "Sheer", "Half open", "Privacy", "Black-out", and from then on it's a single tap from the dropdown — or one service call from an automation.

The feature ships as a new dropdown entity per blind, plus four services: `save_preset` (name + percentage), `save_current_position_as_preset` (name only — captures wherever the blind currently is, handy when you've nudged it manually to the perfect spot), `apply_preset`, and `delete_preset`. Presets live in Home Assistant storage, so they survive restarts and travel with HA snapshots. The dropdown also stays honest: it reflects the live blind position, so it won't keep showing "Half open" once you've moved the blind elsewhere — and if you happen back on a preset value, it re-selects automatically.

**Auto-retry on Bluetooth blips** — open / close / set position / read battery now retry once on transient errors instead of failing. Connection retries also use growing wait times so a busy proxy gets time to recover. New "Command retry attempts" option to tune the behaviour (separate from the existing connection-handshake retry).

Translations covered in en, de, es, fr, it.

83 tests, all passing.

Thanks in advance for the review!
