### PR TITLE
Add per-blind position presets

### DIFF
--- a/custom_components/tuiss2ha/__init__.py
+++ b/custom_components/tuiss2ha/__init__.py
@@ -57,21 +57,21 @@ def _normalize_preset_name(value) -> str:
     return stripped
 
 
-def _normalize_preset_position(value) -> int:
-    """Round to nearest integer, then bound-check 0..100.
+def _normalize_preset_position(value) -> float:
+    """Coerce to float, then bound-check 0..100.
 
-    Using vol.Coerce(int) would silently floor floats (99.9 -> 99). Rounding
-    preserves caller intent for service calls from scripts that compute a
-    percentage. The UI selector already constrains to step=1, so this only
-    affects raw service calls.
+    Blind hardware reports position at 0.1% resolution and the cover
+    entity stores ``_current_cover_position`` as a float. Presets are
+    stored at full precision so save-current → apply round-trips don't
+    drop fractional bits. The UI selector exposes step=0.1.
     """
     try:
-        rounded = int(round(float(value)))
+        v = float(value)
     except (TypeError, ValueError) as exc:
         raise vol.Invalid(f"position must be a number, got {value!r}") from exc
-    if not 0 <= rounded <= 100:
+    if not 0 <= v <= 100:
         raise vol.Invalid("position must be between 0 and 100")
-    return rounded
+    return v
 
 
 _PRESET_NAME_SCHEMA = vol.All(_normalize_preset_name, vol.Length(min=1, max=64))
@@ -327,7 +327,7 @@ def _async_register_preset_services(hass: HomeAssistant) -> None:
             raise HomeAssistantError(
                 f"save_preset: cannot resolve a Tuiss blind for {entity_id}"
             )
-        blind.presets[name] = int(position)
+        blind.presets[name] = float(position)
         await blind.async_save_presets()
         blind.publish_updates()
         _LOGGER.info(
@@ -375,7 +375,7 @@ def _async_register_preset_services(hass: HomeAssistant) -> None:
             )
         # Helper raises HomeAssistantError on unknown preset / missing
         # cover entity, so no further branching needed here.
-        await blind.async_apply_preset(hass, name)
+        await blind.async_apply_preset(name)
 
     hass.services.async_register(
         DOMAIN, SERVICE_SAVE_PRESET, _handle_save_preset, schema=SAVE_PRESET_SCHEMA

--- a/custom_components/tuiss2ha/__init__.py
+++ b/custom_components/tuiss2ha/__init__.py
@@ -8,7 +8,7 @@ import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, ServiceCall, callback
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
 from homeassistant.components import bluetooth
 from homeassistant.components.bluetooth import (
     BluetoothCallbackMatcher,
@@ -47,7 +47,15 @@ SERVICE_SAVE_CURRENT_AS_PRESET = "save_current_position_as_preset"
 SERVICE_DELETE_PRESET = "delete_preset"
 SERVICE_APPLY_PRESET = "apply_preset"
 
-_PRESET_NAME_SCHEMA = vol.All(cv.string, vol.Length(min=1, max=64))
+def _normalize_preset_name(value: str) -> str:
+    """Strip whitespace and reject empty/blank preset names."""
+    stripped = cv.string(value).strip()
+    if not stripped:
+        raise vol.Invalid("Preset name cannot be empty or whitespace only")
+    return stripped
+
+
+_PRESET_NAME_SCHEMA = vol.All(_normalize_preset_name, vol.Length(min=1, max=64))
 _PRESET_POSITION_SCHEMA = vol.All(vol.Coerce(int), vol.Range(min=0, max=100))
 
 SAVE_PRESET_SCHEMA = vol.Schema(
@@ -258,16 +266,18 @@ def _resolve_blind_from_entity_id(hass: HomeAssistant, entity_id: str):
 
     Accepts the cover entity (preferred) or the preset select entity for the
     same blind. Looks up the blind via the entity unique_id which encodes the
-    blind_id.
+    blind_id as ``<blind_id>_<suffix>``.
     """
     ent_reg = er.async_get(hass)
     entry = ent_reg.async_get(entity_id)
     if not entry or entry.platform != DOMAIN:
         return None
-    # unique_id pattern: "<blind_id>_cover" or "<blind_id>_preset_select"
     unique_id = entry.unique_id or ""
-    blind_id = unique_id.rsplit("_", 1)[0] if "_" in unique_id else None
-    # _preset_select uses two underscores at the end; handle that case too
+    # Only accept entity types the preset services are designed to target.
+    # Other tuiss2ha entities (battery sensor, signal strength, etc.) share
+    # the integration platform but are not valid preset-service targets —
+    # refuse them explicitly instead of falling back to a fragile rsplit.
+    blind_id: str | None = None
     for suffix in ("_preset_select", "_cover"):
         if unique_id.endswith(suffix):
             blind_id = unique_id[: -len(suffix)]
@@ -295,8 +305,9 @@ def _async_register_preset_services(hass: HomeAssistant) -> None:
         position = call.data["position"]
         blind = _resolve_blind_from_entity_id(hass, entity_id)
         if not blind:
-            _LOGGER.error("save_preset: cannot resolve blind for %s", entity_id)
-            return
+            raise HomeAssistantError(
+                f"save_preset: cannot resolve a Tuiss blind for {entity_id}"
+            )
         blind.presets[name] = int(position)
         await blind.async_save_presets()
         blind.publish_updates()
@@ -309,11 +320,10 @@ def _async_register_preset_services(hass: HomeAssistant) -> None:
         name = call.data["name"]
         blind = _resolve_blind_from_entity_id(hass, entity_id)
         if not blind:
-            _LOGGER.error(
-                "save_current_position_as_preset: cannot resolve blind for %s",
-                entity_id,
+            raise HomeAssistantError(
+                "save_current_position_as_preset: cannot resolve a Tuiss "
+                f"blind for {entity_id}"
             )
-            return
         # Delegate to the blind so the rounding / persistence / refusal
         # rules live in one place. Returning None means the position
         # isn't known yet — the blind has already logged at warning.
@@ -324,13 +334,13 @@ def _async_register_preset_services(hass: HomeAssistant) -> None:
         name = call.data["name"]
         blind = _resolve_blind_from_entity_id(hass, entity_id)
         if not blind:
-            _LOGGER.error("delete_preset: cannot resolve blind for %s", entity_id)
-            return
-        if name not in blind.presets:
-            _LOGGER.warning(
-                "%s: delete_preset: preset %r not found", blind.name, name
+            raise HomeAssistantError(
+                f"delete_preset: cannot resolve a Tuiss blind for {entity_id}"
             )
-            return
+        if name not in blind.presets:
+            raise HomeAssistantError(
+                f"{blind.name}: preset {name!r} not found"
+            )
         blind.presets.pop(name)
         await blind.async_save_presets()
         blind.publish_updates()
@@ -341,13 +351,13 @@ def _async_register_preset_services(hass: HomeAssistant) -> None:
         name = call.data["name"]
         blind = _resolve_blind_from_entity_id(hass, entity_id)
         if not blind:
-            _LOGGER.error("apply_preset: cannot resolve blind for %s", entity_id)
-            return
-        if name not in blind.presets:
-            _LOGGER.warning(
-                "%s: apply_preset: preset %r not found", blind.name, name
+            raise HomeAssistantError(
+                f"apply_preset: cannot resolve a Tuiss blind for {entity_id}"
             )
-            return
+        if name not in blind.presets:
+            raise HomeAssistantError(
+                f"{blind.name}: preset {name!r} not found"
+            )
         position = blind.presets[name]
 
         # Resolve the cover entity for this blind so the move is dispatched
@@ -357,10 +367,9 @@ def _async_register_preset_services(hass: HomeAssistant) -> None:
             Platform.COVER, DOMAIN, f"{blind.blind_id}_cover"
         )
         if not cover_entity_id:
-            _LOGGER.error(
-                "%s: apply_preset: cover entity not found", blind.name
+            raise HomeAssistantError(
+                f"{blind.name}: cover entity not found for preset apply"
             )
-            return
         await hass.services.async_call(
             "cover",
             "set_cover_position",

--- a/custom_components/tuiss2ha/__init__.py
+++ b/custom_components/tuiss2ha/__init__.py
@@ -47,16 +47,35 @@ SERVICE_SAVE_CURRENT_AS_PRESET = "save_current_position_as_preset"
 SERVICE_DELETE_PRESET = "delete_preset"
 SERVICE_APPLY_PRESET = "apply_preset"
 
-def _normalize_preset_name(value: str) -> str:
+def _normalize_preset_name(value) -> str:
     """Strip whitespace and reject empty/blank preset names."""
-    stripped = cv.string(value).strip()
+    if not isinstance(value, str):
+        raise vol.Invalid("preset name must be a string")
+    stripped = value.strip()
     if not stripped:
         raise vol.Invalid("Preset name cannot be empty or whitespace only")
     return stripped
 
 
+def _normalize_preset_position(value) -> int:
+    """Round to nearest integer, then bound-check 0..100.
+
+    Using vol.Coerce(int) would silently floor floats (99.9 -> 99). Rounding
+    preserves caller intent for service calls from scripts that compute a
+    percentage. The UI selector already constrains to step=1, so this only
+    affects raw service calls.
+    """
+    try:
+        rounded = int(round(float(value)))
+    except (TypeError, ValueError) as exc:
+        raise vol.Invalid(f"position must be a number, got {value!r}") from exc
+    if not 0 <= rounded <= 100:
+        raise vol.Invalid("position must be between 0 and 100")
+    return rounded
+
+
 _PRESET_NAME_SCHEMA = vol.All(_normalize_preset_name, vol.Length(min=1, max=64))
-_PRESET_POSITION_SCHEMA = vol.All(vol.Coerce(int), vol.Range(min=0, max=100))
+_PRESET_POSITION_SCHEMA = _normalize_preset_position
 
 SAVE_PRESET_SCHEMA = vol.Schema(
     {
@@ -354,31 +373,9 @@ def _async_register_preset_services(hass: HomeAssistant) -> None:
             raise HomeAssistantError(
                 f"apply_preset: cannot resolve a Tuiss blind for {entity_id}"
             )
-        if name not in blind.presets:
-            raise HomeAssistantError(
-                f"{blind.name}: preset {name!r} not found"
-            )
-        position = blind.presets[name]
-
-        # Resolve the cover entity for this blind so the move is dispatched
-        # via the existing cover.set_cover_position service.
-        ent_reg = er.async_get(hass)
-        cover_entity_id = ent_reg.async_get_entity_id(
-            Platform.COVER, DOMAIN, f"{blind.blind_id}_cover"
-        )
-        if not cover_entity_id:
-            raise HomeAssistantError(
-                f"{blind.name}: cover entity not found for preset apply"
-            )
-        await hass.services.async_call(
-            "cover",
-            "set_cover_position",
-            {"entity_id": cover_entity_id, "position": position},
-            blocking=False,
-        )
-        _LOGGER.info(
-            "%s: Applied preset %r -> %s%%", blind.name, name, position
-        )
+        # Helper raises HomeAssistantError on unknown preset / missing
+        # cover entity, so no further branching needed here.
+        await blind.async_apply_preset(hass, name)
 
     hass.services.async_register(
         DOMAIN, SERVICE_SAVE_PRESET, _handle_save_preset, schema=SAVE_PRESET_SCHEMA

--- a/custom_components/tuiss2ha/__init__.py
+++ b/custom_components/tuiss2ha/__init__.py
@@ -41,14 +41,13 @@ from .const import (
 PLATFORMS: list[str] = ["cover", "binary_sensor", "sensor", "button", "select"]
 _LOGGER = logging.getLogger(__name__)
 
-# Service names for position presets
 SERVICE_SAVE_PRESET = "save_preset"
 SERVICE_SAVE_CURRENT_AS_PRESET = "save_current_position_as_preset"
 SERVICE_DELETE_PRESET = "delete_preset"
 SERVICE_APPLY_PRESET = "apply_preset"
 
 def _normalize_preset_name(value) -> str:
-    """Strip whitespace and reject empty/blank preset names."""
+    """Strip and reject empty/blank preset names."""
     if not isinstance(value, str):
         raise vol.Invalid("preset name must be a string")
     stripped = value.strip()
@@ -58,13 +57,7 @@ def _normalize_preset_name(value) -> str:
 
 
 def _normalize_preset_position(value) -> float:
-    """Coerce to float, then bound-check 0..100.
-
-    Blind hardware reports position at 0.1% resolution and the cover
-    entity stores ``_current_cover_position`` as a float. Presets are
-    stored at full precision so save-current → apply round-trips don't
-    drop fractional bits. The UI selector exposes step=0.1.
-    """
+    """Coerce to float bound 0..100; preserves 0.1% hardware resolution."""
     try:
         v = float(value)
     except (TypeError, ValueError) as exc:
@@ -184,8 +177,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     entry.async_on_unload(entry.add_update_listener(update_listener))
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
-    # Register preset services once per HA process. Storage is per-blind so
-    # the handlers themselves resolve the target via cover entity_id.
+    # Register preset services once per HA process.
     _async_register_preset_services(hass)
 
     @callback
@@ -281,21 +273,13 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 
 def _resolve_blind_from_entity_id(hass: HomeAssistant, entity_id: str):
-    """Resolve a TuissBlind from a cover/select entity_id, or None.
-
-    Accepts the cover entity (preferred) or the preset select entity for the
-    same blind. Looks up the blind via the entity unique_id which encodes the
-    blind_id as ``<blind_id>_<suffix>``.
-    """
+    """Resolve a TuissBlind from a cover or preset-select entity_id, or None."""
     ent_reg = er.async_get(hass)
     entry = ent_reg.async_get(entity_id)
     if not entry or entry.platform != DOMAIN:
         return None
     unique_id = entry.unique_id or ""
-    # Only accept entity types the preset services are designed to target.
-    # Other tuiss2ha entities (battery sensor, signal strength, etc.) share
-    # the integration platform but are not valid preset-service targets —
-    # refuse them explicitly instead of falling back to a fragile rsplit.
+    # Only cover/preset-select are valid preset-service targets.
     blind_id: str | None = None
     for suffix in ("_preset_select", "_cover"):
         if unique_id.endswith(suffix):
@@ -343,10 +327,15 @@ def _async_register_preset_services(hass: HomeAssistant) -> None:
                 "save_current_position_as_preset: cannot resolve a Tuiss "
                 f"blind for {entity_id}"
             )
-        # Delegate to the blind so the rounding / persistence / refusal
-        # rules live in one place. Returning None means the position
-        # isn't known yet — the blind has already logged at warning.
-        await blind.async_save_current_as_preset(name)
+        # Helper returns None when the live position has never been read;
+        # surface that as an error so automations can branch.
+        result = await blind.async_save_current_as_preset(name)
+        if result is None:
+            raise HomeAssistantError(
+                f"{blind.name}: cannot save preset — current position is "
+                "unknown. Move the blind once so its position is read, then "
+                "try again."
+            )
 
     async def _handle_delete_preset(call: ServiceCall) -> None:
         entity_id = call.data["entity_id"]
@@ -373,8 +362,7 @@ def _async_register_preset_services(hass: HomeAssistant) -> None:
             raise HomeAssistantError(
                 f"apply_preset: cannot resolve a Tuiss blind for {entity_id}"
             )
-        # Helper raises HomeAssistantError on unknown preset / missing
-        # cover entity, so no further branching needed here.
+        # Helper raises HomeAssistantError on unknown preset.
         await blind.async_apply_preset(name)
 
     hass.services.async_register(

--- a/custom_components/tuiss2ha/__init__.py
+++ b/custom_components/tuiss2ha/__init__.py
@@ -43,6 +43,7 @@ _LOGGER = logging.getLogger(__name__)
 
 # Service names for position presets
 SERVICE_SAVE_PRESET = "save_preset"
+SERVICE_SAVE_CURRENT_AS_PRESET = "save_current_position_as_preset"
 SERVICE_DELETE_PRESET = "delete_preset"
 SERVICE_APPLY_PRESET = "apply_preset"
 
@@ -54,6 +55,12 @@ SAVE_PRESET_SCHEMA = vol.Schema(
         vol.Required("entity_id"): cv.entity_id,
         vol.Required("name"): _PRESET_NAME_SCHEMA,
         vol.Required("position"): _PRESET_POSITION_SCHEMA,
+    }
+)
+SAVE_CURRENT_AS_PRESET_SCHEMA = vol.Schema(
+    {
+        vol.Required("entity_id"): cv.entity_id,
+        vol.Required("name"): _PRESET_NAME_SCHEMA,
     }
 )
 DELETE_PRESET_SCHEMA = vol.Schema(
@@ -297,6 +304,21 @@ def _async_register_preset_services(hass: HomeAssistant) -> None:
             "%s: Saved preset %r at %s%%", blind.name, name, position
         )
 
+    async def _handle_save_current_as_preset(call: ServiceCall) -> None:
+        entity_id = call.data["entity_id"]
+        name = call.data["name"]
+        blind = _resolve_blind_from_entity_id(hass, entity_id)
+        if not blind:
+            _LOGGER.error(
+                "save_current_position_as_preset: cannot resolve blind for %s",
+                entity_id,
+            )
+            return
+        # Delegate to the blind so the rounding / persistence / refusal
+        # rules live in one place. Returning None means the position
+        # isn't known yet — the blind has already logged at warning.
+        await blind.async_save_current_as_preset(name)
+
     async def _handle_delete_preset(call: ServiceCall) -> None:
         entity_id = call.data["entity_id"]
         name = call.data["name"]
@@ -351,6 +373,12 @@ def _async_register_preset_services(hass: HomeAssistant) -> None:
 
     hass.services.async_register(
         DOMAIN, SERVICE_SAVE_PRESET, _handle_save_preset, schema=SAVE_PRESET_SCHEMA
+    )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_SAVE_CURRENT_AS_PRESET,
+        _handle_save_current_as_preset,
+        schema=SAVE_CURRENT_AS_PRESET_SCHEMA,
     )
     hass.services.async_register(
         DOMAIN, SERVICE_DELETE_PRESET, _handle_delete_preset, schema=DELETE_PRESET_SCHEMA

--- a/custom_components/tuiss2ha/__init__.py
+++ b/custom_components/tuiss2ha/__init__.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 import logging
 import asyncio
 
+import voluptuous as vol
+
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.components import bluetooth
 from homeassistant.components.bluetooth import (
@@ -14,7 +16,7 @@ from homeassistant.components.bluetooth import (
     async_register_callback,
 )
 from homeassistant.const import CONF_ADDRESS, Platform
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import config_validation as cv, device_registry as dr, entity_registry as er
 
 from .hub import Hub
 from .const import (
@@ -36,17 +38,48 @@ from .const import (
 
 
 
-PLATFORMS: list[str] = ["cover", "binary_sensor", "sensor", "button"]
+PLATFORMS: list[str] = ["cover", "binary_sensor", "sensor", "button", "select"]
 _LOGGER = logging.getLogger(__name__)
+
+# Service names for position presets
+SERVICE_SAVE_PRESET = "save_preset"
+SERVICE_DELETE_PRESET = "delete_preset"
+SERVICE_APPLY_PRESET = "apply_preset"
+
+_PRESET_NAME_SCHEMA = vol.All(cv.string, vol.Length(min=1, max=64))
+_PRESET_POSITION_SCHEMA = vol.All(vol.Coerce(int), vol.Range(min=0, max=100))
+
+SAVE_PRESET_SCHEMA = vol.Schema(
+    {
+        vol.Required("entity_id"): cv.entity_id,
+        vol.Required("name"): _PRESET_NAME_SCHEMA,
+        vol.Required("position"): _PRESET_POSITION_SCHEMA,
+    }
+)
+DELETE_PRESET_SCHEMA = vol.Schema(
+    {
+        vol.Required("entity_id"): cv.entity_id,
+        vol.Required("name"): _PRESET_NAME_SCHEMA,
+    }
+)
+APPLY_PRESET_SCHEMA = vol.Schema(
+    {
+        vol.Required("entity_id"): cv.entity_id,
+        vol.Required("name"): _PRESET_NAME_SCHEMA,
+    }
+)
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Tuiss2HA from a config entry."""
     hub = Hub(hass, entry.data[CONF_BLIND_HOST], entry.data[CONF_BLIND_NAME])
 
     for blind in hub.blinds:
-        
+
         # Load timers
         await blind.async_load_timers()
+
+        # Load position presets (HA-side named positions)
+        await blind.async_load_presets()
         
         # Clean up old duplicate network MAC connections from the device registry DEPRICATE IN FUTURE RELEASE
         device_registry = dr.async_get(hass)
@@ -116,6 +149,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = hub
     entry.async_on_unload(entry.add_update_listener(update_listener))
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    # Register preset services once per HA process. Storage is per-blind so
+    # the handlers themselves resolve the target via cover entity_id.
+    _async_register_preset_services(hass)
 
     @callback
     def _async_discovered_device(
@@ -207,3 +244,117 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok
+
+
+def _resolve_blind_from_entity_id(hass: HomeAssistant, entity_id: str):
+    """Resolve a TuissBlind from a cover/select entity_id, or None.
+
+    Accepts the cover entity (preferred) or the preset select entity for the
+    same blind. Looks up the blind via the entity unique_id which encodes the
+    blind_id.
+    """
+    ent_reg = er.async_get(hass)
+    entry = ent_reg.async_get(entity_id)
+    if not entry or entry.platform != DOMAIN:
+        return None
+    # unique_id pattern: "<blind_id>_cover" or "<blind_id>_preset_select"
+    unique_id = entry.unique_id or ""
+    blind_id = unique_id.rsplit("_", 1)[0] if "_" in unique_id else None
+    # _preset_select uses two underscores at the end; handle that case too
+    for suffix in ("_preset_select", "_cover"):
+        if unique_id.endswith(suffix):
+            blind_id = unique_id[: -len(suffix)]
+            break
+    if not blind_id:
+        return None
+    for hub in hass.data.get(DOMAIN, {}).values():
+        if not isinstance(hub, Hub):
+            continue
+        for blind in hub.blinds:
+            if blind.blind_id == blind_id:
+                return blind
+    return None
+
+
+@callback
+def _async_register_preset_services(hass: HomeAssistant) -> None:
+    """Register preset services once per HA process."""
+    if hass.services.has_service(DOMAIN, SERVICE_SAVE_PRESET):
+        return
+
+    async def _handle_save_preset(call: ServiceCall) -> None:
+        entity_id = call.data["entity_id"]
+        name = call.data["name"]
+        position = call.data["position"]
+        blind = _resolve_blind_from_entity_id(hass, entity_id)
+        if not blind:
+            _LOGGER.error("save_preset: cannot resolve blind for %s", entity_id)
+            return
+        blind.presets[name] = int(position)
+        await blind.async_save_presets()
+        blind.publish_updates()
+        _LOGGER.info(
+            "%s: Saved preset %r at %s%%", blind.name, name, position
+        )
+
+    async def _handle_delete_preset(call: ServiceCall) -> None:
+        entity_id = call.data["entity_id"]
+        name = call.data["name"]
+        blind = _resolve_blind_from_entity_id(hass, entity_id)
+        if not blind:
+            _LOGGER.error("delete_preset: cannot resolve blind for %s", entity_id)
+            return
+        if name not in blind.presets:
+            _LOGGER.warning(
+                "%s: delete_preset: preset %r not found", blind.name, name
+            )
+            return
+        blind.presets.pop(name)
+        await blind.async_save_presets()
+        blind.publish_updates()
+        _LOGGER.info("%s: Deleted preset %r", blind.name, name)
+
+    async def _handle_apply_preset(call: ServiceCall) -> None:
+        entity_id = call.data["entity_id"]
+        name = call.data["name"]
+        blind = _resolve_blind_from_entity_id(hass, entity_id)
+        if not blind:
+            _LOGGER.error("apply_preset: cannot resolve blind for %s", entity_id)
+            return
+        if name not in blind.presets:
+            _LOGGER.warning(
+                "%s: apply_preset: preset %r not found", blind.name, name
+            )
+            return
+        position = blind.presets[name]
+
+        # Resolve the cover entity for this blind so the move is dispatched
+        # via the existing cover.set_cover_position service.
+        ent_reg = er.async_get(hass)
+        cover_entity_id = ent_reg.async_get_entity_id(
+            Platform.COVER, DOMAIN, f"{blind.blind_id}_cover"
+        )
+        if not cover_entity_id:
+            _LOGGER.error(
+                "%s: apply_preset: cover entity not found", blind.name
+            )
+            return
+        await hass.services.async_call(
+            "cover",
+            "set_cover_position",
+            {"entity_id": cover_entity_id, "position": position},
+            blocking=False,
+        )
+        _LOGGER.info(
+            "%s: Applied preset %r -> %s%%", blind.name, name, position
+        )
+
+    hass.services.async_register(
+        DOMAIN, SERVICE_SAVE_PRESET, _handle_save_preset, schema=SAVE_PRESET_SCHEMA
+    )
+    hass.services.async_register(
+        DOMAIN, SERVICE_DELETE_PRESET, _handle_delete_preset, schema=DELETE_PRESET_SCHEMA
+    )
+    hass.services.async_register(
+        DOMAIN, SERVICE_APPLY_PRESET, _handle_apply_preset, schema=APPLY_PRESET_SCHEMA
+    )

--- a/custom_components/tuiss2ha/hub.py
+++ b/custom_components/tuiss2ha/hub.py
@@ -124,6 +124,15 @@ class TuissBlind:
         self.timers = {}
         self._store = Store(self.hub._hass, 1, f"tuiss2ha_{self.host.replace(':', '').lower()}_schedules")
         self._limits_heartbeat_task: asyncio.Task | None = None
+        # Per-blind named position presets ({"Morning": 100, "Movie": 30, ...}).
+        # Stored in HA (separate from on-blind firmware timers) so users can
+        # back them up via HA snapshots and edit via service calls.
+        self.presets: dict[str, int] = {}
+        self._presets_store = Store(
+            self.hub._hass,
+            1,
+            f"tuiss2ha_{self.host.replace(':', '').lower()}_presets",
+        )
 
 
     @property
@@ -593,6 +602,35 @@ class TuissBlind:
     async def async_save_timer(self) -> None:
         """Save schedules to storage."""
         await self._store.async_save(self.timers)
+
+
+    async def async_load_presets(self) -> None:
+        """Load stored position presets."""
+        stored = await self._presets_store.async_load()
+        if stored and isinstance(stored, dict):
+            # Defensive: coerce values to int and drop anything malformed
+            # so a hand-edited or corrupt file can't crash the entity.
+            clean: dict[str, int] = {}
+            for name, position in stored.items():
+                try:
+                    pos_int = int(position)
+                except (TypeError, ValueError):
+                    _LOGGER.warning(
+                        "%s: Dropping preset %r with invalid position %r",
+                        self.name, name, position,
+                    )
+                    continue
+                if not isinstance(name, str) or not name:
+                    continue
+                if 0 <= pos_int <= 100:
+                    clean[name] = pos_int
+            self.presets = clean
+        else:
+            self.presets = {}
+
+    async def async_save_presets(self) -> None:
+        """Persist position presets to storage."""
+        await self._presets_store.async_save(self.presets)
 
 
     async def async_add_timer(self, days: list[str], time_str: str, position: float) -> str:

--- a/custom_components/tuiss2ha/hub.py
+++ b/custom_components/tuiss2ha/hub.py
@@ -145,6 +145,15 @@ class TuissBlind:
         """Return the rssi for the blind."""
         return self._rssi
 
+    @property
+    def current_position(self) -> float | None:
+        """Return the last observed cover position (0-100), or None if unknown.
+
+        Public read-only accessor over the internally tracked position so
+        platforms (select, sensors) don't need to reach into private state.
+        """
+        return self._current_cover_position
+
     def set_rssi(self, rssi: int) -> None:
         """Update the RSSI for the blind."""
         if self._rssi == rssi:
@@ -605,8 +614,21 @@ class TuissBlind:
 
 
     async def async_load_presets(self) -> None:
-        """Load stored position presets."""
-        stored = await self._presets_store.async_load()
+        """Load stored position presets.
+
+        A corrupt or hand-edited storage file would otherwise crash entity
+        setup. Catch broadly and fall back to an empty preset dict so the
+        blind still comes up; the user can re-save presets via the service.
+        """
+        try:
+            stored = await self._presets_store.async_load()
+        except Exception as exc:  # noqa: BLE001
+            _LOGGER.warning(
+                "%s: Failed to load presets from storage (%s); starting empty",
+                self.name, exc,
+            )
+            self.presets = {}
+            return
         if stored and isinstance(stored, dict):
             # Defensive: coerce values to int and drop anything malformed
             # so a hand-edited or corrupt file can't crash the entity.
@@ -632,6 +654,45 @@ class TuissBlind:
         """Persist position presets to storage."""
         await self._presets_store.async_save(self.presets)
 
+    async def async_apply_preset(self, hass, name: str) -> None:
+        """Move the blind to the position stored under ``name``.
+
+        Resolves the cover entity for this blind and dispatches via the
+        existing ``cover.set_cover_position`` service so retries, lock
+        guards, and downstream listeners behave exactly like a manual
+        position change. Raises ``HomeAssistantError`` (imported lazily
+        to keep this module HA-import-light) when the preset is unknown
+        or the cover entity can't be resolved.
+        """
+        # Lazy import so hub.py stays cheap to import from tests that
+        # don't pull homeassistant.exceptions.
+        from homeassistant.exceptions import HomeAssistantError
+        from homeassistant.const import Platform
+        from homeassistant.helpers import entity_registry as er
+
+        if name not in self.presets:
+            raise HomeAssistantError(
+                f"{self.name}: preset {name!r} not found"
+            )
+        position = self.presets[name]
+        ent_reg = er.async_get(hass)
+        cover_entity_id = ent_reg.async_get_entity_id(
+            Platform.COVER, DOMAIN, f"{self.blind_id}_cover"
+        )
+        if not cover_entity_id:
+            raise HomeAssistantError(
+                f"{self.name}: cover entity not found for preset apply"
+            )
+        await hass.services.async_call(
+            "cover",
+            "set_cover_position",
+            {"entity_id": cover_entity_id, "position": position},
+            blocking=True,
+        )
+        _LOGGER.info(
+            "%s: Applied preset %r -> %s%%", self.name, name, position
+        )
+
     async def async_save_current_as_preset(self, name: str) -> int | None:
         """Save the live cover position under ``name`` as a preset.
 
@@ -639,7 +700,16 @@ class TuissBlind:
         position is currently unknown (never been read). Callers are
         expected to surface an appropriate user-facing message in the
         None case — the method itself only logs at warning level.
+
+        Defensive: strip the supplied name and raise ValueError on empty
+        so direct Python callers can't sneak past the service-schema
+        normalizer with whitespace-only input.
         """
+        if not isinstance(name, str):
+            raise ValueError("preset name must be a string")
+        name = name.strip()
+        if not name:
+            raise ValueError("preset name cannot be empty or whitespace only")
         current = self._current_cover_position
         if current is None:
             _LOGGER.warning(

--- a/custom_components/tuiss2ha/hub.py
+++ b/custom_components/tuiss2ha/hub.py
@@ -632,6 +632,31 @@ class TuissBlind:
         """Persist position presets to storage."""
         await self._presets_store.async_save(self.presets)
 
+    async def async_save_current_as_preset(self, name: str) -> int | None:
+        """Save the live cover position under ``name`` as a preset.
+
+        Returns the integer position that was stored, or None if the
+        position is currently unknown (never been read). Callers are
+        expected to surface an appropriate user-facing message in the
+        None case — the method itself only logs at warning level.
+        """
+        current = self._current_cover_position
+        if current is None:
+            _LOGGER.warning(
+                "%s: Cannot save preset %r — current position is unknown",
+                self.name, name,
+            )
+            return None
+        position = int(round(current))
+        self.presets[name] = position
+        await self.async_save_presets()
+        self.publish_updates()
+        _LOGGER.info(
+            "%s: Saved preset %r at current position %s%% (raw %s)",
+            self.name, name, position, current,
+        )
+        return position
+
 
     async def async_add_timer(self, days: list[str], time_str: str, position: float) -> str:
         """Add a new schedule."""

--- a/custom_components/tuiss2ha/hub.py
+++ b/custom_components/tuiss2ha/hub.py
@@ -127,7 +127,7 @@ class TuissBlind:
         # Per-blind named position presets ({"Morning": 100, "Movie": 30, ...}).
         # Stored in HA (separate from on-blind firmware timers) so users can
         # back them up via HA snapshots and edit via service calls.
-        self.presets: dict[str, int] = {}
+        self.presets: dict[str, float] = {}
         self._presets_store = Store(
             self.hub._hass,
             1,
@@ -630,12 +630,13 @@ class TuissBlind:
             self.presets = {}
             return
         if stored and isinstance(stored, dict):
-            # Defensive: coerce values to int and drop anything malformed
+            # Defensive: coerce values to float and drop anything malformed
             # so a hand-edited or corrupt file can't crash the entity.
-            clean: dict[str, int] = {}
+            # Floats preserve the 0.1% resolution the blind hardware uses.
+            clean: dict[str, float] = {}
             for name, position in stored.items():
                 try:
-                    pos_int = int(position)
+                    pos_f = float(position)
                 except (TypeError, ValueError):
                     _LOGGER.warning(
                         "%s: Dropping preset %r with invalid position %r",
@@ -644,8 +645,8 @@ class TuissBlind:
                     continue
                 if not isinstance(name, str) or not name:
                     continue
-                if 0 <= pos_int <= 100:
-                    clean[name] = pos_int
+                if 0 <= pos_f <= 100:
+                    clean[name] = pos_f
             self.presets = clean
         else:
             self.presets = {}
@@ -654,49 +655,47 @@ class TuissBlind:
         """Persist position presets to storage."""
         await self._presets_store.async_save(self.presets)
 
-    async def async_apply_preset(self, hass, name: str) -> None:
+    async def async_apply_preset(self, name: str) -> None:
         """Move the blind to the position stored under ``name``.
 
-        Resolves the cover entity for this blind and dispatches via the
-        existing ``cover.set_cover_position`` service so retries, lock
-        guards, and downstream listeners behave exactly like a manual
-        position change. Raises ``HomeAssistantError`` (imported lazily
-        to keep this module HA-import-light) when the preset is unknown
-        or the cover entity can't be resolved.
-        """
-        # Lazy import so hub.py stays cheap to import from tests that
-        # don't pull homeassistant.exceptions.
-        from homeassistant.exceptions import HomeAssistantError
-        from homeassistant.const import Platform
-        from homeassistant.helpers import entity_registry as er
+        Dispatches directly to ``async_move_cover`` rather than the HA
+        ``cover.set_cover_position`` service. The HA service schema is
+        ``vol.Coerce(int)``, which would truncate fractional positions —
+        bypassing it keeps the blind's native 0.1% resolution intact
+        end-to-end (preset save -> storage -> apply -> firmware command).
 
+        Raises ``HomeAssistantError`` when the preset is unknown.
+        """
         if name not in self.presets:
             raise HomeAssistantError(
                 f"{self.name}: preset {name!r} not found"
             )
-        position = self.presets[name]
-        ent_reg = er.async_get(hass)
-        cover_entity_id = ent_reg.async_get_entity_id(
-            Platform.COVER, DOMAIN, f"{self.blind_id}_cover"
-        )
-        if not cover_entity_id:
-            raise HomeAssistantError(
-                f"{self.name}: cover entity not found for preset apply"
+        position = float(self.presets[name])
+        # Mirror cover.async_set_cover_position: pick a direction from
+        # the live position and pass the inverted target the firmware
+        # expects (0 == open at the cover layer, 100 == open at the
+        # blind layer — async_move_cover does another 100-x flip).
+        current = self._current_cover_position
+        if current is None:
+            current = 0.0
+        movement_direction = 1 if current <= position else -1
+        try:
+            await self.async_move_cover(
+                movement_direction=movement_direction,
+                target_position=100 - position,
             )
-        await hass.services.async_call(
-            "cover",
-            "set_cover_position",
-            {"entity_id": cover_entity_id, "position": position},
-            blocking=True,
-        )
+        except (ConnectionTimeout, DeviceNotFound) as e:
+            raise HomeAssistantError(
+                f"{self.name}: preset {name!r} failed to apply: {e}"
+            ) from e
         _LOGGER.info(
             "%s: Applied preset %r -> %s%%", self.name, name, position
         )
 
-    async def async_save_current_as_preset(self, name: str) -> int | None:
+    async def async_save_current_as_preset(self, name: str) -> float | None:
         """Save the live cover position under ``name`` as a preset.
 
-        Returns the integer position that was stored, or None if the
+        Returns the float position that was stored, or None if the
         position is currently unknown (never been read). Callers are
         expected to surface an appropriate user-facing message in the
         None case — the method itself only logs at warning level.
@@ -717,13 +716,14 @@ class TuissBlind:
                 self.name, name,
             )
             return None
-        position = int(round(current))
+        # Preserve hardware-side 0.1% precision rather than rounding.
+        position = float(current)
         self.presets[name] = position
         await self.async_save_presets()
         self.publish_updates()
         _LOGGER.info(
-            "%s: Saved preset %r at current position %s%% (raw %s)",
-            self.name, name, position, current,
+            "%s: Saved preset %r at current position %s%%",
+            self.name, name, position,
         )
         return position
 

--- a/custom_components/tuiss2ha/hub.py
+++ b/custom_components/tuiss2ha/hub.py
@@ -124,9 +124,7 @@ class TuissBlind:
         self.timers = {}
         self._store = Store(self.hub._hass, 1, f"tuiss2ha_{self.host.replace(':', '').lower()}_schedules")
         self._limits_heartbeat_task: asyncio.Task | None = None
-        # Per-blind named position presets ({"Morning": 100, "Movie": 30, ...}).
-        # Stored in HA (separate from on-blind firmware timers) so users can
-        # back them up via HA snapshots and edit via service calls.
+        # HA-side named position presets (separate from firmware timers).
         self.presets: dict[str, float] = {}
         self._presets_store = Store(
             self.hub._hass,
@@ -147,11 +145,7 @@ class TuissBlind:
 
     @property
     def current_position(self) -> float | None:
-        """Return the last observed cover position (0-100), or None if unknown.
-
-        Public read-only accessor over the internally tracked position so
-        platforms (select, sensors) don't need to reach into private state.
-        """
+        """Return the last observed cover position (0-100), or None if unknown."""
         return self._current_cover_position
 
     def set_rssi(self, rssi: int) -> None:
@@ -614,12 +608,7 @@ class TuissBlind:
 
 
     async def async_load_presets(self) -> None:
-        """Load stored position presets.
-
-        A corrupt or hand-edited storage file would otherwise crash entity
-        setup. Catch broadly and fall back to an empty preset dict so the
-        blind still comes up; the user can re-save presets via the service.
-        """
+        """Load stored position presets; fall back to empty on corruption."""
         try:
             stored = await self._presets_store.async_load()
         except Exception as exc:  # noqa: BLE001
@@ -630,11 +619,14 @@ class TuissBlind:
             self.presets = {}
             return
         if stored and isinstance(stored, dict):
-            # Defensive: coerce values to float and drop anything malformed
-            # so a hand-edited or corrupt file can't crash the entity.
-            # Floats preserve the 0.1% resolution the blind hardware uses.
             clean: dict[str, float] = {}
             for name, position in stored.items():
+                if not isinstance(name, str) or not name.strip():
+                    _LOGGER.warning(
+                        "%s: Dropping preset with invalid name %r",
+                        self.name, name,
+                    )
+                    continue
                 try:
                     pos_f = float(position)
                 except (TypeError, ValueError):
@@ -643,11 +635,17 @@ class TuissBlind:
                         self.name, name, position,
                     )
                     continue
-                if not isinstance(name, str) or not name:
+                if not 0 <= pos_f <= 100:
+                    _LOGGER.warning(
+                        "%s: Dropping preset %r with out-of-range position %s",
+                        self.name, name, pos_f,
+                    )
                     continue
-                if 0 <= pos_f <= 100:
-                    clean[name] = pos_f
+                clean[name] = pos_f
             self.presets = clean
+            # Re-persist if we dropped anything so the next restart is clean.
+            if len(clean) != len(stored):
+                await self._presets_store.async_save(clean)
         else:
             self.presets = {}
 
@@ -658,26 +656,23 @@ class TuissBlind:
     async def async_apply_preset(self, name: str) -> None:
         """Move the blind to the position stored under ``name``.
 
-        Dispatches directly to ``async_move_cover`` rather than the HA
-        ``cover.set_cover_position`` service. The HA service schema is
-        ``vol.Coerce(int)``, which would truncate fractional positions —
-        bypassing it keeps the blind's native 0.1% resolution intact
-        end-to-end (preset save -> storage -> apply -> firmware command).
-
-        Raises ``HomeAssistantError`` when the preset is unknown.
+        Dispatches directly to ``async_move_cover`` to bypass HA's
+        ``cover.set_cover_position`` int-coercion and preserve 0.1%
+        precision end-to-end. Refuses when the live position is unknown
+        rather than guessing a direction.
         """
         if name not in self.presets:
             raise HomeAssistantError(
                 f"{self.name}: preset {name!r} not found"
             )
         position = float(self.presets[name])
-        # Mirror cover.async_set_cover_position: pick a direction from
-        # the live position and pass the inverted target the firmware
-        # expects (0 == open at the cover layer, 100 == open at the
-        # blind layer — async_move_cover does another 100-x flip).
         current = self._current_cover_position
         if current is None:
-            current = 0.0
+            raise HomeAssistantError(
+                f"{self.name}: preset {name!r} cannot apply — current "
+                "position is unknown. Move the blind once so its "
+                "position is read, then try again."
+            )
         movement_direction = 1 if current <= position else -1
         try:
             await self.async_move_cover(
@@ -693,16 +688,10 @@ class TuissBlind:
         )
 
     async def async_save_current_as_preset(self, name: str) -> float | None:
-        """Save the live cover position under ``name`` as a preset.
+        """Save the live cover position under ``name``.
 
-        Returns the float position that was stored, or None if the
-        position is currently unknown (never been read). Callers are
-        expected to surface an appropriate user-facing message in the
-        None case — the method itself only logs at warning level.
-
-        Defensive: strip the supplied name and raise ValueError on empty
-        so direct Python callers can't sneak past the service-schema
-        normalizer with whitespace-only input.
+        Returns the stored float, or None if position has never been read.
+        Raises ValueError on empty/non-string names.
         """
         if not isinstance(name, str):
             raise ValueError("preset name must be a string")
@@ -716,8 +705,8 @@ class TuissBlind:
                 self.name, name,
             )
             return None
-        # Preserve hardware-side 0.1% precision rather than rounding.
-        position = float(current)
+        # Clamp against transient out-of-range frames.
+        position = max(0.0, min(100.0, float(current)))
         self.presets[name] = position
         await self.async_save_presets()
         self.publish_updates()

--- a/custom_components/tuiss2ha/hub.py
+++ b/custom_components/tuiss2ha/hub.py
@@ -679,7 +679,7 @@ class TuissBlind:
                 movement_direction=movement_direction,
                 target_position=100 - position,
             )
-        except (ConnectionTimeout, DeviceNotFound) as e:
+        except (ConnectionTimeout, DeviceNotFound, HomeAssistantError) as e:
             raise HomeAssistantError(
                 f"{self.name}: preset {name!r} failed to apply: {e}"
             ) from e

--- a/custom_components/tuiss2ha/select.py
+++ b/custom_components/tuiss2ha/select.py
@@ -73,21 +73,21 @@ class TuissPresetSelect(SelectEntity):
         - Re-arriving at a preset position re-selects it automatically.
         - When two presets share a value, the alphabetically-first
           name wins so the result is stable.
-        - Float positions are rounded before comparing so the entity
-          doesn't flicker on intermediate readings.
+        - Compares with a 0.5%% tolerance so intermediate readings from
+          the BLE position stream don't flicker the dropdown off the
+          matching preset name (firmware reports at 0.1%% resolution).
         """
         pos = self.blind.current_position
         if pos is None:
             return None
-        target = int(round(pos))
         for name in sorted(self.blind.presets):
-            if self.blind.presets[name] == target:
+            if abs(self.blind.presets[name] - pos) < 0.5:
                 return name
         return None
 
     async def async_select_option(self, option: str) -> None:
         """Apply the chosen preset by delegating to the blind helper."""
-        await self.blind.async_apply_preset(self.hass, option)
+        await self.blind.async_apply_preset(option)
         # No need to set _attr_current_option — current_option is
         # derived from the live position, which the cover will publish
         # via publish_updates() once the move starts.

--- a/custom_components/tuiss2ha/select.py
+++ b/custom_components/tuiss2ha/select.py
@@ -8,6 +8,7 @@ from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -90,11 +91,10 @@ class TuissPresetSelect(SelectEntity):
     async def async_select_option(self, option: str) -> None:
         """Apply the chosen preset by moving the cover to its position."""
         if option not in self.blind.presets:
-            _LOGGER.warning(
-                "%s: Preset %r not found; available: %s",
-                self.blind.name, option, list(self.blind.presets),
+            raise HomeAssistantError(
+                f"{self.blind.name}: preset {option!r} not found; "
+                f"available: {list(self.blind.presets)}"
             )
-            return
         position = self.blind.presets[option]
         _LOGGER.info(
             "%s: Applying preset %r -> position %s%%",
@@ -107,11 +107,9 @@ class TuissPresetSelect(SelectEntity):
             Platform.COVER, DOMAIN, cover_unique_id
         )
         if not cover_entity_id:
-            _LOGGER.warning(
-                "%s: Could not find cover entity for preset %r",
-                self.blind.name, option,
+            raise HomeAssistantError(
+                f"{self.blind.name}: cover entity not found for preset {option!r}"
             )
-            return
 
         await self.hass.services.async_call(
             "cover",

--- a/custom_components/tuiss2ha/select.py
+++ b/custom_components/tuiss2ha/select.py
@@ -66,31 +66,18 @@ class TuissPresetSelect(SelectEntity):
 
     @property
     def current_option(self) -> str | None:
-        """Match the live cover position to a preset, else ``None``.
-
-        Recomputed every read so the dropdown reflects reality:
-        - Manual cover moves clear the selection.
-        - Re-arriving at a preset position re-selects it automatically.
-        - When two presets share a value, the alphabetically-first
-          name wins so the result is stable.
-        - Compares with a 0.5%% tolerance so intermediate readings from
-          the BLE position stream don't flicker the dropdown off the
-          matching preset name (firmware reports at 0.1%% resolution).
-        """
+        """Match the live position to a preset within 0.5% tolerance, else None."""
         pos = self.blind.current_position
         if pos is None:
             return None
         for name in sorted(self.blind.presets):
-            if abs(self.blind.presets[name] - pos) < 0.5:
+            if abs(self.blind.presets[name] - pos) <= 0.5:
                 return name
         return None
 
     async def async_select_option(self, option: str) -> None:
-        """Apply the chosen preset by delegating to the blind helper."""
+        """Apply the chosen preset."""
         await self.blind.async_apply_preset(option)
-        # No need to set _attr_current_option — current_option is
-        # derived from the live position, which the cover will publish
-        # via publish_updates() once the move starts.
 
     async def async_added_to_hass(self) -> None:
         """Register callbacks so the dropdown refreshes on state changes."""

--- a/custom_components/tuiss2ha/select.py
+++ b/custom_components/tuiss2ha/select.py
@@ -33,9 +33,11 @@ async def async_setup_entry(
 class TuissPresetSelect(SelectEntity):
     """Dropdown of saved position presets for a Tuiss blind.
 
-    Picking an option calls the cover's set_cover_position service with the
-    stored value. The list of options is derived from blind.presets so it
-    stays in sync after save_preset / delete_preset service calls.
+    The selected option is *derived* from the live cover position rather
+    than stored: any preset whose value matches the current position is
+    shown as selected, and the dropdown clears as soon as the blind is
+    moved away. This keeps the entity from claiming the blind is at
+    "Movie" when the user has manually slid it elsewhere.
     """
 
     _attr_has_entity_name = True
@@ -53,7 +55,6 @@ class TuissPresetSelect(SelectEntity):
             manufacturer=self.blind.hub.manufacturer,
             model=self.blind.model,
         )
-        self._attr_current_option = None
 
     @property
     def options(self) -> list[str]:
@@ -64,6 +65,27 @@ class TuissPresetSelect(SelectEntity):
     def available(self) -> bool:
         """Available only when at least one preset is defined."""
         return bool(self.blind.presets)
+
+    @property
+    def current_option(self) -> str | None:
+        """Match the live cover position to a preset, else ``None``.
+
+        Recomputed every read so the dropdown reflects reality:
+        - Manual cover moves clear the selection.
+        - Re-arriving at a preset position re-selects it automatically.
+        - When two presets share a value, the alphabetically-first
+          name wins so the result is stable.
+        - Float positions are rounded before comparing so the entity
+          doesn't flicker on intermediate readings.
+        """
+        pos = self.blind._current_cover_position
+        if pos is None:
+            return None
+        target = int(round(pos))
+        for name in sorted(self.blind.presets):
+            if self.blind.presets[name] == target:
+                return name
+        return None
 
     async def async_select_option(self, option: str) -> None:
         """Apply the chosen preset by moving the cover to its position."""
@@ -97,11 +119,12 @@ class TuissPresetSelect(SelectEntity):
             {"entity_id": cover_entity_id, "position": position},
             blocking=False,
         )
-        self._attr_current_option = option
-        self.async_write_ha_state()
+        # No need to set _attr_current_option — current_option is
+        # derived from the live position, which the cover will publish
+        # via publish_updates() once the move starts.
 
     async def async_added_to_hass(self) -> None:
-        """Register callbacks so the dropdown refreshes on preset changes."""
+        """Register callbacks so the dropdown refreshes on state changes."""
         self.blind.register_callback(self._handle_update)
 
     async def async_will_remove_from_hass(self) -> None:
@@ -110,8 +133,5 @@ class TuissPresetSelect(SelectEntity):
 
     @callback
     def _handle_update(self) -> None:
-        """Refresh entity state when presets change."""
-        # Clear current_option if the previously selected preset was removed
-        if self._attr_current_option and self._attr_current_option not in self.blind.presets:
-            self._attr_current_option = None
+        """Refresh entity state when presets or position change."""
         self.async_write_ha_state()

--- a/custom_components/tuiss2ha/select.py
+++ b/custom_components/tuiss2ha/select.py
@@ -6,10 +6,7 @@ import logging
 
 from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -79,7 +76,7 @@ class TuissPresetSelect(SelectEntity):
         - Float positions are rounded before comparing so the entity
           doesn't flicker on intermediate readings.
         """
-        pos = self.blind._current_cover_position
+        pos = self.blind.current_position
         if pos is None:
             return None
         target = int(round(pos))
@@ -89,34 +86,8 @@ class TuissPresetSelect(SelectEntity):
         return None
 
     async def async_select_option(self, option: str) -> None:
-        """Apply the chosen preset by moving the cover to its position."""
-        if option not in self.blind.presets:
-            raise HomeAssistantError(
-                f"{self.blind.name}: preset {option!r} not found; "
-                f"available: {list(self.blind.presets)}"
-            )
-        position = self.blind.presets[option]
-        _LOGGER.info(
-            "%s: Applying preset %r -> position %s%%",
-            self.blind.name, option, position,
-        )
-
-        ent_reg = er.async_get(self.hass)
-        cover_unique_id = f"{self.blind.blind_id}_cover"
-        cover_entity_id = ent_reg.async_get_entity_id(
-            Platform.COVER, DOMAIN, cover_unique_id
-        )
-        if not cover_entity_id:
-            raise HomeAssistantError(
-                f"{self.blind.name}: cover entity not found for preset {option!r}"
-            )
-
-        await self.hass.services.async_call(
-            "cover",
-            "set_cover_position",
-            {"entity_id": cover_entity_id, "position": position},
-            blocking=False,
-        )
+        """Apply the chosen preset by delegating to the blind helper."""
+        await self.blind.async_apply_preset(self.hass, option)
         # No need to set _attr_current_option — current_option is
         # derived from the live position, which the cover will publish
         # via publish_updates() once the move starts.

--- a/custom_components/tuiss2ha/select.py
+++ b/custom_components/tuiss2ha/select.py
@@ -1,0 +1,117 @@
+"""Position preset select entity for Tuiss2HA."""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.select import SelectEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .hub import Hub, TuissBlind
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the Tuiss select entities (one preset selector per blind)."""
+    hub: Hub = hass.data[DOMAIN][config_entry.entry_id]
+    async_add_entities(
+        [TuissPresetSelect(blind) for blind in hub.blinds]
+    )
+
+
+class TuissPresetSelect(SelectEntity):
+    """Dropdown of saved position presets for a Tuiss blind.
+
+    Picking an option calls the cover's set_cover_position service with the
+    stored value. The list of options is derived from blind.presets so it
+    stays in sync after save_preset / delete_preset service calls.
+    """
+
+    _attr_has_entity_name = True
+    _attr_icon = "mdi:bookmark-multiple"
+    should_poll = False
+
+    def __init__(self, blind: TuissBlind) -> None:
+        """Initialize the select entity."""
+        self.blind = blind
+        self._attr_unique_id = f"{self.blind.blind_id}_preset_select"
+        self._attr_name = "Preset"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, self.blind.blind_id)},
+            name=self.blind.name,
+            manufacturer=self.blind.hub.manufacturer,
+            model=self.blind.model,
+        )
+        self._attr_current_option = None
+
+    @property
+    def options(self) -> list[str]:
+        """Return preset names sorted alphabetically for stable display."""
+        return sorted(self.blind.presets.keys())
+
+    @property
+    def available(self) -> bool:
+        """Available only when at least one preset is defined."""
+        return bool(self.blind.presets)
+
+    async def async_select_option(self, option: str) -> None:
+        """Apply the chosen preset by moving the cover to its position."""
+        if option not in self.blind.presets:
+            _LOGGER.warning(
+                "%s: Preset %r not found; available: %s",
+                self.blind.name, option, list(self.blind.presets),
+            )
+            return
+        position = self.blind.presets[option]
+        _LOGGER.info(
+            "%s: Applying preset %r -> position %s%%",
+            self.blind.name, option, position,
+        )
+
+        ent_reg = er.async_get(self.hass)
+        cover_unique_id = f"{self.blind.blind_id}_cover"
+        cover_entity_id = ent_reg.async_get_entity_id(
+            Platform.COVER, DOMAIN, cover_unique_id
+        )
+        if not cover_entity_id:
+            _LOGGER.warning(
+                "%s: Could not find cover entity for preset %r",
+                self.blind.name, option,
+            )
+            return
+
+        await self.hass.services.async_call(
+            "cover",
+            "set_cover_position",
+            {"entity_id": cover_entity_id, "position": position},
+            blocking=False,
+        )
+        self._attr_current_option = option
+        self.async_write_ha_state()
+
+    async def async_added_to_hass(self) -> None:
+        """Register callbacks so the dropdown refreshes on preset changes."""
+        self.blind.register_callback(self._handle_update)
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Remove callbacks."""
+        self.blind.remove_callback(self._handle_update)
+
+    @callback
+    def _handle_update(self) -> None:
+        """Refresh entity state when presets change."""
+        # Clear current_option if the previously selected preset was removed
+        if self._attr_current_option and self._attr_current_option not in self.blind.presets:
+            self._attr_current_option = None
+        self.async_write_ha_state()

--- a/custom_components/tuiss2ha/services.yaml
+++ b/custom_components/tuiss2ha/services.yaml
@@ -124,3 +124,51 @@ delete_blind_timer:
           integration: tuiss2ha
           domain: sensor
           multiple: false
+
+save_preset:
+  # Save a named position preset for a blind. Existing names are overwritten.
+  # Stored in HA (separate from on-blind firmware timers).
+  fields:
+    entity_id:
+      required: true
+      selector:
+        entity:
+          integration: tuiss2ha
+    name:
+      required: true
+      selector:
+        text:
+    position:
+      required: true
+      selector:
+        number:
+          min: 0
+          max: 100
+          step: 1
+          mode: slider
+
+delete_preset:
+  # Remove a named position preset from a blind.
+  fields:
+    entity_id:
+      required: true
+      selector:
+        entity:
+          integration: tuiss2ha
+    name:
+      required: true
+      selector:
+        text:
+
+apply_preset:
+  # Move a blind to the position stored under the named preset.
+  fields:
+    entity_id:
+      required: true
+      selector:
+        entity:
+          integration: tuiss2ha
+    name:
+      required: true
+      selector:
+        text:

--- a/custom_components/tuiss2ha/services.yaml
+++ b/custom_components/tuiss2ha/services.yaml
@@ -147,6 +147,21 @@ save_preset:
           step: 1
           mode: slider
 
+save_current_position_as_preset:
+  # Save the blind's current position under a named preset. Useful when
+  # you don't know the exact percentage — move the blind where you want
+  # it, then call this with just a name.
+  fields:
+    entity_id:
+      required: true
+      selector:
+        entity:
+          integration: tuiss2ha
+    name:
+      required: true
+      selector:
+        text:
+
 delete_preset:
   # Remove a named position preset from a blind.
   fields:

--- a/custom_components/tuiss2ha/services.yaml
+++ b/custom_components/tuiss2ha/services.yaml
@@ -134,6 +134,9 @@ save_preset:
       selector:
         entity:
           integration: tuiss2ha
+          domain:
+            - cover
+            - select
     name:
       required: true
       selector:
@@ -157,6 +160,9 @@ save_current_position_as_preset:
       selector:
         entity:
           integration: tuiss2ha
+          domain:
+            - cover
+            - select
     name:
       required: true
       selector:
@@ -170,6 +176,9 @@ delete_preset:
       selector:
         entity:
           integration: tuiss2ha
+          domain:
+            - cover
+            - select
     name:
       required: true
       selector:
@@ -183,6 +192,9 @@ apply_preset:
       selector:
         entity:
           integration: tuiss2ha
+          domain:
+            - cover
+            - select
     name:
       required: true
       selector:

--- a/custom_components/tuiss2ha/services.yaml
+++ b/custom_components/tuiss2ha/services.yaml
@@ -147,7 +147,7 @@ save_preset:
         number:
           min: 0
           max: 100
-          step: 1
+          step: 0.1
           mode: slider
 
 save_current_position_as_preset:

--- a/custom_components/tuiss2ha/translations/de.json
+++ b/custom_components/tuiss2ha/translations/de.json
@@ -204,6 +204,20 @@
                 }
             }
         },
+        "save_current_position_as_preset": {
+            "name": "Aktuelle Position als Voreinstellung speichern",
+            "description": "Speichert die aktuelle Position der Jalousie unter einer benannten Voreinstellung. Bewegen Sie die Jalousie zuerst in die gewünschte Position — der Dienst speichert die zuletzt beobachtete Position, ohne nach einem Prozentsatz zu fragen.",
+            "fields": {
+                "entity_id": {
+                    "name": "Jalousie-Entität",
+                    "description": "Wählen Sie die Jalousie-Cover- oder Voreinstellungs-Entität aus."
+                },
+                "name": {
+                    "name": "Name der Voreinstellung",
+                    "description": "Kurze Bezeichnung der Voreinstellung (z. B. Lesen, Sonnenuntergang)."
+                }
+            }
+        },
         "delete_preset": {
             "name": "Positions-Voreinstellung löschen",
             "description": "Entfernt eine benannte Positions-Voreinstellung von einer Jalousie.",

--- a/custom_components/tuiss2ha/translations/de.json
+++ b/custom_components/tuiss2ha/translations/de.json
@@ -185,6 +185,52 @@
                     "description": "Wählen Sie den Timer aus, den Sie entfernen möchten."
                 }
             }
+        },
+        "save_preset": {
+            "name": "Positions-Voreinstellung speichern",
+            "description": "Speichert eine benannte Positions-Voreinstellung für eine Jalousie. Bestehende Namen werden überschrieben. In Home Assistant gespeichert (nicht in der Jalousien-Firmware).",
+            "fields": {
+                "entity_id": {
+                    "name": "Jalousie-Entität",
+                    "description": "Wählen Sie die Jalousie-Cover- oder Voreinstellungs-Entität aus."
+                },
+                "name": {
+                    "name": "Name der Voreinstellung",
+                    "description": "Kurze Bezeichnung der Voreinstellung (z. B. Morgen, Film, Schlafen)."
+                },
+                "position": {
+                    "name": "Position",
+                    "description": "Position, zu der die Voreinstellung fährt (0 = geschlossen, 100 = offen)."
+                }
+            }
+        },
+        "delete_preset": {
+            "name": "Positions-Voreinstellung löschen",
+            "description": "Entfernt eine benannte Positions-Voreinstellung von einer Jalousie.",
+            "fields": {
+                "entity_id": {
+                    "name": "Jalousie-Entität",
+                    "description": "Wählen Sie die Jalousie-Cover- oder Voreinstellungs-Entität aus."
+                },
+                "name": {
+                    "name": "Name der Voreinstellung",
+                    "description": "Name der zu entfernenden Voreinstellung."
+                }
+            }
+        },
+        "apply_preset": {
+            "name": "Positions-Voreinstellung anwenden",
+            "description": "Bewegt eine Jalousie auf die in der Voreinstellung gespeicherte Position.",
+            "fields": {
+                "entity_id": {
+                    "name": "Jalousie-Entität",
+                    "description": "Wählen Sie die Jalousie-Cover- oder Voreinstellungs-Entität aus."
+                },
+                "name": {
+                    "name": "Name der Voreinstellung",
+                    "description": "Name der anzuwendenden Voreinstellung."
+                }
+            }
         }
     },
     "exceptions": {

--- a/custom_components/tuiss2ha/translations/en.json
+++ b/custom_components/tuiss2ha/translations/en.json
@@ -183,6 +183,52 @@
                         "description": "Select the timer you wish to remove."
                     }
                 }
+        },
+        "save_preset": {
+            "name": "Save Position Preset",
+            "description": "Save a named position preset for a blind. Re-using an existing name overwrites it. Stored in Home Assistant (not on the blind firmware).",
+            "fields": {
+                "entity_id": {
+                    "name": "Blind Entity",
+                    "description": "Select the blind cover or its preset selector entity."
+                },
+                "name": {
+                    "name": "Preset Name",
+                    "description": "Short label for the preset (e.g. Morning, Movie, Sleep)."
+                },
+                "position": {
+                    "name": "Position",
+                    "description": "Position the preset moves to (0 = closed, 100 = open)."
+                }
+            }
+        },
+        "delete_preset": {
+            "name": "Delete Position Preset",
+            "description": "Remove a named position preset from a blind.",
+            "fields": {
+                "entity_id": {
+                    "name": "Blind Entity",
+                    "description": "Select the blind cover or its preset selector entity."
+                },
+                "name": {
+                    "name": "Preset Name",
+                    "description": "Name of the preset to remove."
+                }
+            }
+        },
+        "apply_preset": {
+            "name": "Apply Position Preset",
+            "description": "Move a blind to the position stored under the named preset.",
+            "fields": {
+                "entity_id": {
+                    "name": "Blind Entity",
+                    "description": "Select the blind cover or its preset selector entity."
+                },
+                "name": {
+                    "name": "Preset Name",
+                    "description": "Name of the preset to apply."
+                }
+            }
         }
     }
 ,

--- a/custom_components/tuiss2ha/translations/en.json
+++ b/custom_components/tuiss2ha/translations/en.json
@@ -202,6 +202,20 @@
                 }
             }
         },
+        "save_current_position_as_preset": {
+            "name": "Save Current Position as Preset",
+            "description": "Save the blind's current position under a named preset. Move the blind to the desired position first — this service stores whatever position the integration last observed without asking for a percentage.",
+            "fields": {
+                "entity_id": {
+                    "name": "Blind Entity",
+                    "description": "Select the blind cover or its preset selector entity."
+                },
+                "name": {
+                    "name": "Preset Name",
+                    "description": "Short label for the preset (e.g. Reading, Sunset)."
+                }
+            }
+        },
         "delete_preset": {
             "name": "Delete Position Preset",
             "description": "Remove a named position preset from a blind.",

--- a/custom_components/tuiss2ha/translations/es.json
+++ b/custom_components/tuiss2ha/translations/es.json
@@ -204,6 +204,20 @@
                 }
             }
         },
+        "save_current_position_as_preset": {
+            "name": "Guardar posición actual como preajuste",
+            "description": "Guarda la posición actual de la persiana con un nombre de preajuste. Mueve primero la persiana a la posición deseada — este servicio guarda la última posición observada por la integración sin pedir un porcentaje.",
+            "fields": {
+                "entity_id": {
+                    "name": "Entidad de persiana",
+                    "description": "Selecciona la entidad de la persiana o su selector de preajustes."
+                },
+                "name": {
+                    "name": "Nombre del preajuste",
+                    "description": "Etiqueta corta para el preajuste (ej. Lectura, Atardecer)."
+                }
+            }
+        },
         "delete_preset": {
             "name": "Eliminar preajuste de posición",
             "description": "Elimina un preajuste de posición con nombre de una persiana.",

--- a/custom_components/tuiss2ha/translations/es.json
+++ b/custom_components/tuiss2ha/translations/es.json
@@ -185,6 +185,52 @@
                     "description": "Selecciona el temporizador que deseas eliminar."
                 }
             }
+        },
+        "save_preset": {
+            "name": "Guardar preajuste de posición",
+            "description": "Guarda un preajuste de posición con nombre para una persiana. Los nombres existentes se sobrescriben. Se almacena en Home Assistant (no en el firmware de la persiana).",
+            "fields": {
+                "entity_id": {
+                    "name": "Entidad de persiana",
+                    "description": "Selecciona la entidad de la persiana o su selector de preajustes."
+                },
+                "name": {
+                    "name": "Nombre del preajuste",
+                    "description": "Etiqueta corta para el preajuste (ej. Mañana, Película, Dormir)."
+                },
+                "position": {
+                    "name": "Posición",
+                    "description": "Posición a la que se mueve el preajuste (0 = cerrada, 100 = abierta)."
+                }
+            }
+        },
+        "delete_preset": {
+            "name": "Eliminar preajuste de posición",
+            "description": "Elimina un preajuste de posición con nombre de una persiana.",
+            "fields": {
+                "entity_id": {
+                    "name": "Entidad de persiana",
+                    "description": "Selecciona la entidad de la persiana o su selector de preajustes."
+                },
+                "name": {
+                    "name": "Nombre del preajuste",
+                    "description": "Nombre del preajuste a eliminar."
+                }
+            }
+        },
+        "apply_preset": {
+            "name": "Aplicar preajuste de posición",
+            "description": "Mueve una persiana a la posición guardada bajo el preajuste con nombre.",
+            "fields": {
+                "entity_id": {
+                    "name": "Entidad de persiana",
+                    "description": "Selecciona la entidad de la persiana o su selector de preajustes."
+                },
+                "name": {
+                    "name": "Nombre del preajuste",
+                    "description": "Nombre del preajuste a aplicar."
+                }
+            }
         }
     },
     "exceptions": {

--- a/custom_components/tuiss2ha/translations/fr.json
+++ b/custom_components/tuiss2ha/translations/fr.json
@@ -204,6 +204,20 @@
                 }
             }
         },
+        "save_current_position_as_preset": {
+            "name": "Enregistrer la position actuelle comme préréglage",
+            "description": "Enregistre la position actuelle du store sous un préréglage nommé. Déplacez d'abord le store à la position souhaitée — ce service enregistre la dernière position observée par l'intégration sans demander de pourcentage.",
+            "fields": {
+                "entity_id": {
+                    "name": "Entité du store",
+                    "description": "Sélectionnez l'entité du store ou son sélecteur de préréglages."
+                },
+                "name": {
+                    "name": "Nom du préréglage",
+                    "description": "Étiquette courte pour le préréglage (ex. Lecture, Coucher de soleil)."
+                }
+            }
+        },
         "delete_preset": {
             "name": "Supprimer le préréglage de position",
             "description": "Supprime un préréglage de position nommé d'un store.",

--- a/custom_components/tuiss2ha/translations/fr.json
+++ b/custom_components/tuiss2ha/translations/fr.json
@@ -185,6 +185,52 @@
                     "description": "Sélectionnez le minuteur que vous souhaitez supprimer."
                 }
             }
+        },
+        "save_preset": {
+            "name": "Enregistrer le préréglage de position",
+            "description": "Enregistre un préréglage de position nommé pour un store. Les noms existants sont écrasés. Stocké dans Home Assistant (pas dans le firmware du store).",
+            "fields": {
+                "entity_id": {
+                    "name": "Entité du store",
+                    "description": "Sélectionnez l'entité du store ou son sélecteur de préréglages."
+                },
+                "name": {
+                    "name": "Nom du préréglage",
+                    "description": "Étiquette courte pour le préréglage (ex. Matin, Film, Sommeil)."
+                },
+                "position": {
+                    "name": "Position",
+                    "description": "Position à laquelle le préréglage déplace le store (0 = fermé, 100 = ouvert)."
+                }
+            }
+        },
+        "delete_preset": {
+            "name": "Supprimer le préréglage de position",
+            "description": "Supprime un préréglage de position nommé d'un store.",
+            "fields": {
+                "entity_id": {
+                    "name": "Entité du store",
+                    "description": "Sélectionnez l'entité du store ou son sélecteur de préréglages."
+                },
+                "name": {
+                    "name": "Nom du préréglage",
+                    "description": "Nom du préréglage à supprimer."
+                }
+            }
+        },
+        "apply_preset": {
+            "name": "Appliquer le préréglage de position",
+            "description": "Déplace un store à la position enregistrée sous le préréglage nommé.",
+            "fields": {
+                "entity_id": {
+                    "name": "Entité du store",
+                    "description": "Sélectionnez l'entité du store ou son sélecteur de préréglages."
+                },
+                "name": {
+                    "name": "Nom du préréglage",
+                    "description": "Nom du préréglage à appliquer."
+                }
+            }
         }
     },
     "exceptions": {

--- a/custom_components/tuiss2ha/translations/it.json
+++ b/custom_components/tuiss2ha/translations/it.json
@@ -185,6 +185,52 @@
                     "description": "Seleziona il timer che desideri rimuovere."
                 }
             }
+        },
+        "save_preset": {
+            "name": "Salva preset di posizione",
+            "description": "Salva un preset di posizione con nome per una tenda. I nomi esistenti vengono sovrascritti. Memorizzato in Home Assistant (non nel firmware della tenda).",
+            "fields": {
+                "entity_id": {
+                    "name": "Entità tenda",
+                    "description": "Seleziona l'entità della tenda o il suo selettore di preset."
+                },
+                "name": {
+                    "name": "Nome del preset",
+                    "description": "Etichetta breve per il preset (es. Mattino, Film, Notte)."
+                },
+                "position": {
+                    "name": "Posizione",
+                    "description": "Posizione a cui il preset sposta la tenda (0 = chiusa, 100 = aperta)."
+                }
+            }
+        },
+        "delete_preset": {
+            "name": "Elimina preset di posizione",
+            "description": "Rimuove un preset di posizione con nome da una tenda.",
+            "fields": {
+                "entity_id": {
+                    "name": "Entità tenda",
+                    "description": "Seleziona l'entità della tenda o il suo selettore di preset."
+                },
+                "name": {
+                    "name": "Nome del preset",
+                    "description": "Nome del preset da rimuovere."
+                }
+            }
+        },
+        "apply_preset": {
+            "name": "Applica preset di posizione",
+            "description": "Sposta una tenda alla posizione salvata nel preset con il nome indicato.",
+            "fields": {
+                "entity_id": {
+                    "name": "Entità tenda",
+                    "description": "Seleziona l'entità della tenda o il suo selettore di preset."
+                },
+                "name": {
+                    "name": "Nome del preset",
+                    "description": "Nome del preset da applicare."
+                }
+            }
         }
     },
     "exceptions": {

--- a/custom_components/tuiss2ha/translations/it.json
+++ b/custom_components/tuiss2ha/translations/it.json
@@ -204,6 +204,20 @@
                 }
             }
         },
+        "save_current_position_as_preset": {
+            "name": "Salva posizione attuale come preset",
+            "description": "Salva la posizione attuale della tenda con un nome di preset. Sposta prima la tenda nella posizione desiderata — questo servizio memorizza l'ultima posizione osservata dall'integrazione senza chiedere una percentuale.",
+            "fields": {
+                "entity_id": {
+                    "name": "Entità tenda",
+                    "description": "Seleziona l'entità della tenda o il suo selettore di preset."
+                },
+                "name": {
+                    "name": "Nome del preset",
+                    "description": "Etichetta breve per il preset (es. Lettura, Tramonto)."
+                }
+            }
+        },
         "delete_preset": {
             "name": "Elimina preset di posizione",
             "description": "Rimuove un preset di posizione con nome da una tenda.",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,6 +45,7 @@ def pytest_sessionstart(session):
         "SensorEntity": type("SensorEntity", (MockEntity,), {}),
         "BinarySensorEntity": type("BinarySensorEntity", (MockEntity,), {}),
         "ButtonEntity": type("ButtonEntity", (MockEntity,), {}),
+        "SelectEntity": type("SelectEntity", (MockEntity,), {}),
     }
 
     # Create a mock for the 'homeassistant' root module
@@ -91,6 +92,7 @@ def pytest_sessionstart(session):
     sys.modules["homeassistant.components.binary_sensor"] = MagicMock(**mock_entity_classes)
     sys.modules["homeassistant.components.button"] = MagicMock(**mock_entity_classes)
     sys.modules["homeassistant.components.cover"] = MagicMock(**mock_entity_classes)
+    sys.modules["homeassistant.components.select"] = MagicMock(**mock_entity_classes)
 
     # Mock other required modules that don't contain entity base classes
     import types

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -80,15 +80,15 @@ async def test_async_save_presets_persists(mock_hass):
 
 @pytest.mark.asyncio
 async def test_async_load_presets_coerces_string_positions(mock_hass):
-    """Storage layer may give back strings; loader should coerce to int."""
+    """Storage layer may give back strings; loader should coerce to float."""
     tb = _make_blind(mock_hass)
     tb._presets_store = MagicMock()
-    tb._presets_store.async_load = AsyncMock(return_value={"Morning": "75"})
+    tb._presets_store.async_load = AsyncMock(return_value={"Morning": "75.5"})
 
     await tb.async_load_presets()
 
-    assert tb.presets == {"Morning": 75}
-    assert isinstance(tb.presets["Morning"], int)
+    assert tb.presets == {"Morning": 75.5}
+    assert isinstance(tb.presets["Morning"], float)
 
 
 @pytest.mark.asyncio
@@ -104,8 +104,12 @@ async def test_async_load_presets_handles_non_dict_payload(mock_hass):
 
 
 @pytest.mark.asyncio
-async def test_save_current_stores_rounded_position(mock_hass):
-    """async_save_current_as_preset rounds the live position to int."""
+async def test_save_current_preserves_float_precision(mock_hass):
+    """async_save_current_as_preset stores the live position as a float.
+
+    The blind hardware reports position at 0.1% resolution. Preserve it
+    end-to-end so save → apply round-trips don't drop fractional bits.
+    """
     tb = _make_blind(mock_hass)
     tb._presets_store = MagicMock()
     tb._presets_store.async_save = AsyncMock()
@@ -114,9 +118,9 @@ async def test_save_current_stores_rounded_position(mock_hass):
 
     result = await tb.async_save_current_as_preset("Reading")
 
-    assert result == 43
-    assert tb.presets == {"Reading": 43}
-    tb._presets_store.async_save.assert_awaited_once_with({"Reading": 43})
+    assert result == 42.7
+    assert tb.presets == {"Reading": 42.7}
+    tb._presets_store.async_save.assert_awaited_once_with({"Reading": 42.7})
     tb.publish_updates.assert_called_once()
 
 
@@ -149,14 +153,14 @@ async def test_save_current_overwrites_existing_name(mock_hass):
 
     result = await tb.async_save_current_as_preset("Reading")
 
-    assert result == 75
-    assert tb.presets == {"Reading": 75}
-    tb._presets_store.async_save.assert_awaited_once_with({"Reading": 75})
+    assert result == 75.0
+    assert tb.presets == {"Reading": 75.0}
+    tb._presets_store.async_save.assert_awaited_once_with({"Reading": 75.0})
 
 
 @pytest.mark.asyncio
 async def test_save_current_handles_integer_position(mock_hass):
-    """An integer position is stored as-is (round is a no-op)."""
+    """An integer-typed position is coerced to float for consistency."""
     tb = _make_blind(mock_hass)
     tb._presets_store = MagicMock()
     tb._presets_store.async_save = AsyncMock()
@@ -165,8 +169,8 @@ async def test_save_current_handles_integer_position(mock_hass):
 
     result = await tb.async_save_current_as_preset("Half")
 
-    assert result == 50
-    assert tb.presets == {"Half": 50}
+    assert result == 50.0
+    assert tb.presets == {"Half": 50.0}
 
 
 def _make_select(mock_hass):
@@ -203,13 +207,23 @@ def test_select_current_option_none_when_no_match(mock_hass):
     assert sel.current_option is None
 
 
-def test_select_current_option_rounds_float(mock_hass):
-    """Float position is rounded before comparing — 99.7 matches 100."""
+def test_select_current_option_matches_with_tolerance(mock_hass):
+    """0.5% tolerance accepts intermediate BLE readings near a preset."""
     sel, tb = _make_select(mock_hass)
-    tb.presets = {"Morning": 100}
+    tb.presets = {"Morning": 100.0}
+    # 99.7 vs 100.0 — within tolerance.
     tb._current_cover_position = 99.7
 
     assert sel.current_option == "Morning"
+
+
+def test_select_current_option_preserves_float_preset(mock_hass):
+    """Float-stored preset matches exact float live position."""
+    sel, tb = _make_select(mock_hass)
+    tb.presets = {"Reading": 42.7}
+    tb._current_cover_position = 42.7
+
+    assert sel.current_option == "Reading"
 
 
 def test_select_current_option_alphabetical_tiebreak(mock_hass):
@@ -362,14 +376,15 @@ async def test_select_raises_on_unknown_option(mock_hass):
 # ---------------------------------------------------------------------------
 
 
-def test_position_schema_rounds_floats():
-    """vol.Coerce(int) used to floor 99.9 -> 99; rounding preserves intent."""
+def test_position_schema_preserves_floats():
+    """Schema keeps float precision so storage round-trips at 0.1%."""
     from custom_components.tuiss2ha import _PRESET_POSITION_SCHEMA
 
-    assert _PRESET_POSITION_SCHEMA(99.9) == 100
-    assert _PRESET_POSITION_SCHEMA(49.5) == 50
-    assert _PRESET_POSITION_SCHEMA(0) == 0
-    assert _PRESET_POSITION_SCHEMA(100) == 100
+    assert _PRESET_POSITION_SCHEMA(99.9) == 99.9
+    assert _PRESET_POSITION_SCHEMA(49.5) == 49.5
+    assert _PRESET_POSITION_SCHEMA(0) == 0.0
+    assert _PRESET_POSITION_SCHEMA(100) == 100.0
+    assert isinstance(_PRESET_POSITION_SCHEMA(42), float)
 
 
 def test_position_schema_rejects_out_of_range():
@@ -426,4 +441,4 @@ async def test_async_apply_preset_raises_for_unknown(mock_hass):
     tb.presets = {"Morning": 80}
 
     with pytest.raises(HomeAssistantError, match="not found"):
-        await tb.async_apply_preset(mock_hass, "Nope")
+        await tb.async_apply_preset("Nope")

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -167,3 +167,96 @@ async def test_save_current_handles_integer_position(mock_hass):
 
     assert result == 50
     assert tb.presets == {"Half": 50}
+
+
+def _make_select(mock_hass):
+    """Build a TuissPresetSelect bound to a fresh blind."""
+    from custom_components.tuiss2ha.select import TuissPresetSelect
+    tb = _make_blind(mock_hass)
+    return TuissPresetSelect(tb), tb
+
+
+def test_select_current_option_none_when_position_unknown(mock_hass):
+    """Position never read -> dropdown shows nothing selected."""
+    sel, tb = _make_select(mock_hass)
+    tb.presets = {"Movie": 30, "Morning": 100}
+    tb._current_cover_position = None
+
+    assert sel.current_option is None
+
+
+def test_select_current_option_matches_exact_position(mock_hass):
+    """Live position equal to a preset value -> that preset is selected."""
+    sel, tb = _make_select(mock_hass)
+    tb.presets = {"Movie": 30, "Morning": 100, "Sleep": 0}
+    tb._current_cover_position = 30
+
+    assert sel.current_option == "Movie"
+
+
+def test_select_current_option_none_when_no_match(mock_hass):
+    """Position between presets -> nothing selected."""
+    sel, tb = _make_select(mock_hass)
+    tb.presets = {"Movie": 30, "Morning": 100}
+    tb._current_cover_position = 55
+
+    assert sel.current_option is None
+
+
+def test_select_current_option_rounds_float(mock_hass):
+    """Float position is rounded before comparing — 99.7 matches 100."""
+    sel, tb = _make_select(mock_hass)
+    tb.presets = {"Morning": 100}
+    tb._current_cover_position = 99.7
+
+    assert sel.current_option == "Morning"
+
+
+def test_select_current_option_alphabetical_tiebreak(mock_hass):
+    """When two presets share a value, the alphabetically-first wins."""
+    sel, tb = _make_select(mock_hass)
+    tb.presets = {"Zeta": 50, "Alpha": 50, "Mid": 50}
+    tb._current_cover_position = 50
+
+    # sorted({"Zeta","Alpha","Mid"}) -> "Alpha","Mid","Zeta" -> first match Alpha
+    assert sel.current_option == "Alpha"
+
+
+def test_select_current_option_clears_after_manual_move(mock_hass):
+    """A manual move away from the preset clears the selection."""
+    sel, tb = _make_select(mock_hass)
+    tb.presets = {"Movie": 30}
+    tb._current_cover_position = 30
+    assert sel.current_option == "Movie"
+
+    # User manually drags blind to 70 — no service call, just position update
+    tb._current_cover_position = 70
+    assert sel.current_option is None
+
+
+def test_select_current_option_re_selects_on_return(mock_hass):
+    """Returning to a preset position re-selects it automatically."""
+    sel, tb = _make_select(mock_hass)
+    tb.presets = {"Reading": 42}
+    tb._current_cover_position = 100  # somewhere else
+    assert sel.current_option is None
+
+    # Move back to the preset value
+    tb._current_cover_position = 42
+    assert sel.current_option == "Reading"
+
+
+def test_select_options_sorted(mock_hass):
+    """Options list is alphabetically sorted for stable UI display."""
+    sel, tb = _make_select(mock_hass)
+    tb.presets = {"Zeta": 1, "Alpha": 2, "Mid": 3}
+
+    assert sel.options == ["Alpha", "Mid", "Zeta"]
+
+
+def test_select_unavailable_when_no_presets(mock_hass):
+    """The entity reports itself unavailable when no presets are defined."""
+    sel, tb = _make_select(mock_hass)
+    tb.presets = {}
+
+    assert sel.available is False

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -1,0 +1,103 @@
+"""Tests for the position presets feature: storage + select entity + services."""
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.tuiss2ha.hub import TuissBlind
+
+
+def _make_blind(mock_hass) -> TuissBlind:
+    """Build a TuissBlind with bluetooth discovery patched."""
+    fake_device = MagicMock()
+    fake_device.name = "TB-01"
+    with patch(
+        "custom_components.tuiss2ha.hub.bluetooth.async_ble_device_from_address",
+        return_value=fake_device,
+    ):
+        hub = MagicMock()
+        hub._hass = mock_hass
+        return TuissBlind("AA:BB:CC:DD:EE:FF", "Test", hub)
+
+
+@pytest.mark.asyncio
+async def test_async_load_presets_empty_when_store_empty(mock_hass):
+    """No stored data should leave presets as an empty dict."""
+    tb = _make_blind(mock_hass)
+    tb._presets_store = MagicMock()
+    tb._presets_store.async_load = AsyncMock(return_value=None)
+
+    await tb.async_load_presets()
+
+    assert tb.presets == {}
+
+
+@pytest.mark.asyncio
+async def test_async_load_presets_round_trips(mock_hass):
+    """Stored dict is loaded verbatim into blind.presets."""
+    tb = _make_blind(mock_hass)
+    tb._presets_store = MagicMock()
+    tb._presets_store.async_load = AsyncMock(
+        return_value={"Morning": 100, "Movie": 30, "Sleep": 0}
+    )
+
+    await tb.async_load_presets()
+
+    assert tb.presets == {"Morning": 100, "Movie": 30, "Sleep": 0}
+
+
+@pytest.mark.asyncio
+async def test_async_load_presets_drops_invalid_entries(mock_hass):
+    """Malformed entries are dropped without raising."""
+    tb = _make_blind(mock_hass)
+    tb._presets_store = MagicMock()
+    tb._presets_store.async_load = AsyncMock(
+        return_value={
+            "Good": 50,
+            "OutOfRange": 150,            # > 100 -> dropped
+            "Negative": -1,                # < 0 -> dropped
+            "BadType": "not-a-number",     # not coercible -> dropped
+            "": 25,                         # empty name -> dropped
+        }
+    )
+
+    await tb.async_load_presets()
+
+    assert tb.presets == {"Good": 50}
+
+
+@pytest.mark.asyncio
+async def test_async_save_presets_persists(mock_hass):
+    """Saving forwards the current presets dict to the store."""
+    tb = _make_blind(mock_hass)
+    tb._presets_store = MagicMock()
+    tb._presets_store.async_save = AsyncMock()
+    tb.presets = {"X": 10, "Y": 90}
+
+    await tb.async_save_presets()
+
+    tb._presets_store.async_save.assert_awaited_once_with({"X": 10, "Y": 90})
+
+
+@pytest.mark.asyncio
+async def test_async_load_presets_coerces_string_positions(mock_hass):
+    """Storage layer may give back strings; loader should coerce to int."""
+    tb = _make_blind(mock_hass)
+    tb._presets_store = MagicMock()
+    tb._presets_store.async_load = AsyncMock(return_value={"Morning": "75"})
+
+    await tb.async_load_presets()
+
+    assert tb.presets == {"Morning": 75}
+    assert isinstance(tb.presets["Morning"], int)
+
+
+@pytest.mark.asyncio
+async def test_async_load_presets_handles_non_dict_payload(mock_hass):
+    """A corrupt non-dict payload should reset to empty rather than crash."""
+    tb = _make_blind(mock_hass)
+    tb._presets_store = MagicMock()
+    tb._presets_store.async_load = AsyncMock(return_value=["unexpected", "list"])
+
+    await tb.async_load_presets()
+
+    assert tb.presets == {}

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -350,6 +350,80 @@ async def test_select_raises_on_unknown_option(mock_hass):
 
     sel, tb = _make_select(mock_hass)
     tb.presets = {"Morning": 80}
+    # SelectEntity reads self.hass; the mocked base doesn't supply it.
+    sel.hass = mock_hass
 
     with pytest.raises(HomeAssistantError, match="not found"):
         await sel.async_select_option("Nope")
+
+
+# ---------------------------------------------------------------------------
+# Behaviour added for review feedback
+# ---------------------------------------------------------------------------
+
+
+def test_position_schema_rounds_floats():
+    """vol.Coerce(int) used to floor 99.9 -> 99; rounding preserves intent."""
+    from custom_components.tuiss2ha import _PRESET_POSITION_SCHEMA
+
+    assert _PRESET_POSITION_SCHEMA(99.9) == 100
+    assert _PRESET_POSITION_SCHEMA(49.5) == 50
+    assert _PRESET_POSITION_SCHEMA(0) == 0
+    assert _PRESET_POSITION_SCHEMA(100) == 100
+
+
+def test_position_schema_rejects_out_of_range():
+    """Bound check is still applied after rounding."""
+    import voluptuous as vol
+    from custom_components.tuiss2ha import _PRESET_POSITION_SCHEMA
+
+    with pytest.raises(vol.Invalid):
+        _PRESET_POSITION_SCHEMA(-1)
+    with pytest.raises(vol.Invalid):
+        _PRESET_POSITION_SCHEMA(101)
+    with pytest.raises(vol.Invalid):
+        _PRESET_POSITION_SCHEMA("not-a-number")
+
+
+def test_current_position_property_exposes_internal_state(mock_hass):
+    """Platforms must read position via the public property, not _current_cover_position."""
+    tb = _make_blind(mock_hass)
+    assert tb.current_position is None
+    tb._current_cover_position = 42.7
+    assert tb.current_position == 42.7
+
+
+@pytest.mark.asyncio
+async def test_async_save_current_rejects_blank_name(mock_hass):
+    """Hub-level guard so direct Python callers can't bypass the service schema."""
+    tb = _make_blind(mock_hass)
+    tb._current_cover_position = 50
+
+    with pytest.raises(ValueError):
+        await tb.async_save_current_as_preset("")
+    with pytest.raises(ValueError):
+        await tb.async_save_current_as_preset("   ")
+
+
+@pytest.mark.asyncio
+async def test_async_load_presets_swallows_storage_errors(mock_hass):
+    """Corrupt storage must not crash entity setup."""
+    tb = _make_blind(mock_hass)
+    tb._presets_store = MagicMock()
+    tb._presets_store.async_load = AsyncMock(side_effect=ValueError("corrupt JSON"))
+
+    await tb.async_load_presets()
+
+    assert tb.presets == {}
+
+
+@pytest.mark.asyncio
+async def test_async_apply_preset_raises_for_unknown(mock_hass):
+    """Hub helper raises HomeAssistantError so both UI and services share behaviour."""
+    from homeassistant.exceptions import HomeAssistantError
+
+    tb = _make_blind(mock_hass)
+    tb.presets = {"Morning": 80}
+
+    with pytest.raises(HomeAssistantError, match="not found"):
+        await tb.async_apply_preset(mock_hass, "Nope")

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -101,3 +101,69 @@ async def test_async_load_presets_handles_non_dict_payload(mock_hass):
     await tb.async_load_presets()
 
     assert tb.presets == {}
+
+
+@pytest.mark.asyncio
+async def test_save_current_stores_rounded_position(mock_hass):
+    """async_save_current_as_preset rounds the live position to int."""
+    tb = _make_blind(mock_hass)
+    tb._presets_store = MagicMock()
+    tb._presets_store.async_save = AsyncMock()
+    tb.publish_updates = MagicMock()
+    tb._current_cover_position = 42.7
+
+    result = await tb.async_save_current_as_preset("Reading")
+
+    assert result == 43
+    assert tb.presets == {"Reading": 43}
+    tb._presets_store.async_save.assert_awaited_once_with({"Reading": 43})
+    tb.publish_updates.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_save_current_returns_none_when_position_unknown(mock_hass):
+    """If the cover position has never been read, refuse and don't persist."""
+    tb = _make_blind(mock_hass)
+    tb._presets_store = MagicMock()
+    tb._presets_store.async_save = AsyncMock()
+    tb.publish_updates = MagicMock()
+    tb._current_cover_position = None
+
+    result = await tb.async_save_current_as_preset("Reading")
+
+    assert result is None
+    assert tb.presets == {}
+    tb._presets_store.async_save.assert_not_called()
+    tb.publish_updates.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_save_current_overwrites_existing_name(mock_hass):
+    """Re-using a preset name overwrites the old position."""
+    tb = _make_blind(mock_hass)
+    tb._presets_store = MagicMock()
+    tb._presets_store.async_save = AsyncMock()
+    tb.publish_updates = MagicMock()
+    tb.presets = {"Reading": 10}
+    tb._current_cover_position = 75
+
+    result = await tb.async_save_current_as_preset("Reading")
+
+    assert result == 75
+    assert tb.presets == {"Reading": 75}
+    tb._presets_store.async_save.assert_awaited_once_with({"Reading": 75})
+
+
+@pytest.mark.asyncio
+async def test_save_current_handles_integer_position(mock_hass):
+    """An integer position is stored as-is (round is a no-op)."""
+    tb = _make_blind(mock_hass)
+    tb._presets_store = MagicMock()
+    tb._presets_store.async_save = AsyncMock()
+    tb.publish_updates = MagicMock()
+    tb._current_cover_position = 50
+
+    result = await tb.async_save_current_as_preset("Half")
+
+    assert result == 50
+    assert tb.presets == {"Half": 50}

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -47,7 +47,7 @@ async def test_async_load_presets_round_trips(mock_hass):
 
 @pytest.mark.asyncio
 async def test_async_load_presets_drops_invalid_entries(mock_hass):
-    """Malformed entries are dropped without raising."""
+    """Malformed entries are dropped and the cleaned dict is re-persisted."""
     tb = _make_blind(mock_hass)
     tb._presets_store = MagicMock()
     tb._presets_store.async_load = AsyncMock(
@@ -59,10 +59,27 @@ async def test_async_load_presets_drops_invalid_entries(mock_hass):
             "": 25,                         # empty name -> dropped
         }
     )
+    tb._presets_store.async_save = AsyncMock()
 
     await tb.async_load_presets()
 
-    assert tb.presets == {"Good": 50}
+    assert tb.presets == {"Good": 50.0}
+    # Cleaned dict re-persisted so the next restart doesn't re-walk garbage.
+    tb._presets_store.async_save.assert_awaited_once_with({"Good": 50.0})
+
+
+@pytest.mark.asyncio
+async def test_async_load_presets_does_not_resave_when_clean(mock_hass):
+    """If every stored entry is valid, no re-save happens at load time."""
+    tb = _make_blind(mock_hass)
+    tb._presets_store = MagicMock()
+    tb._presets_store.async_load = AsyncMock(return_value={"Morning": 80})
+    tb._presets_store.async_save = AsyncMock()
+
+    await tb.async_load_presets()
+
+    assert tb.presets == {"Morning": 80.0}
+    tb._presets_store.async_save.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -439,6 +456,57 @@ async def test_async_apply_preset_raises_for_unknown(mock_hass):
 
     tb = _make_blind(mock_hass)
     tb.presets = {"Morning": 80}
+    tb._current_cover_position = 50  # known; otherwise the apply guard short-circuits
 
     with pytest.raises(HomeAssistantError, match="not found"):
         await tb.async_apply_preset("Nope")
+
+
+@pytest.mark.asyncio
+async def test_async_apply_preset_refuses_when_position_unknown(mock_hass):
+    """Apply must refuse rather than guess direction from an unknown position."""
+    from homeassistant.exceptions import HomeAssistantError
+
+    tb = _make_blind(mock_hass)
+    tb.presets = {"Morning": 80}
+    tb._current_cover_position = None
+
+    with pytest.raises(HomeAssistantError, match="unknown"):
+        await tb.async_apply_preset("Morning")
+
+
+@pytest.mark.asyncio
+async def test_async_apply_preset_dispatches_with_correct_direction(mock_hass):
+    """Success path: helper resolves direction and calls async_move_cover."""
+    tb = _make_blind(mock_hass)
+    tb.presets = {"Up": 80.0, "Down": 20.0}
+    tb._current_cover_position = 50.0
+    tb.async_move_cover = AsyncMock()
+
+    await tb.async_apply_preset("Up")
+    tb.async_move_cover.assert_awaited_with(
+        movement_direction=1, target_position=20.0
+    )
+
+    tb.async_move_cover.reset_mock()
+    await tb.async_apply_preset("Down")
+    tb.async_move_cover.assert_awaited_with(
+        movement_direction=-1, target_position=80.0
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_save_current_clamps_out_of_range(mock_hass):
+    """A bad BLE frame can't poison storage with a >100 or <0 value."""
+    tb = _make_blind(mock_hass)
+    tb._presets_store = MagicMock()
+    tb._presets_store.async_save = AsyncMock()
+    tb.publish_updates = MagicMock()
+
+    tb._current_cover_position = 105.4
+    result = await tb.async_save_current_as_preset("HighGlitch")
+    assert result == 100.0
+
+    tb._current_cover_position = -5.0
+    result = await tb.async_save_current_as_preset("LowGlitch")
+    assert result == 0.0

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -260,3 +260,96 @@ def test_select_unavailable_when_no_presets(mock_hass):
     tb.presets = {}
 
     assert sel.available is False
+
+
+# ---------------------------------------------------------------------------
+# Schema + resolver guards
+# ---------------------------------------------------------------------------
+
+
+def test_preset_name_schema_strips_whitespace():
+    """The shared name schema must trim leading/trailing whitespace."""
+    from custom_components.tuiss2ha import _PRESET_NAME_SCHEMA
+
+    assert _PRESET_NAME_SCHEMA("  Morning  ") == "Morning"
+
+
+def test_preset_name_schema_rejects_blank():
+    """Whitespace-only or empty names must be refused before reaching storage."""
+    import voluptuous as vol
+    from custom_components.tuiss2ha import _PRESET_NAME_SCHEMA
+
+    with pytest.raises(vol.Invalid):
+        _PRESET_NAME_SCHEMA("")
+    with pytest.raises(vol.Invalid):
+        _PRESET_NAME_SCHEMA("   ")
+    with pytest.raises(vol.Invalid):
+        _PRESET_NAME_SCHEMA("\t\n")
+
+
+def test_resolve_rejects_non_preset_entity(mock_hass):
+    """Resolver must refuse tuiss2ha entities that aren't cover/preset select.
+
+    Battery, signal-strength, model etc. share the integration platform but
+    are not valid preset-service targets. The resolver should return None
+    rather than falling back to a fragile rsplit that accidentally yields
+    the correct blind only because MAC addresses lack underscores.
+    """
+    from custom_components.tuiss2ha import _resolve_blind_from_entity_id, DOMAIN
+    from custom_components.tuiss2ha.hub import Hub
+
+    blind = MagicMock()
+    blind.blind_id = "AA:BB:CC:DD:EE:FF"
+    hub = MagicMock(spec=Hub)
+    hub.blinds = [blind]
+    mock_hass.data = {DOMAIN: {"entry": hub}}
+
+    # Fake the entity registry — return an entry for a battery sensor.
+    fake_entry = MagicMock()
+    fake_entry.platform = DOMAIN
+    fake_entry.unique_id = "AA:BB:CC:DD:EE:FF_battery"
+
+    with patch(
+        "custom_components.tuiss2ha.er.async_get",
+        return_value=MagicMock(async_get=MagicMock(return_value=fake_entry)),
+    ):
+        result = _resolve_blind_from_entity_id(
+            mock_hass, "binary_sensor.blind_test_battery"
+        )
+
+    assert result is None
+
+
+def test_resolve_accepts_cover_and_preset_select(mock_hass):
+    """Resolver must accept both the cover entity and the preset select entity."""
+    from custom_components.tuiss2ha import _resolve_blind_from_entity_id, DOMAIN
+    from custom_components.tuiss2ha.hub import Hub
+
+    blind = MagicMock()
+    blind.blind_id = "AA:BB:CC:DD:EE:FF"
+    hub = MagicMock(spec=Hub)
+    hub.blinds = [blind]
+    mock_hass.data = {DOMAIN: {"entry": hub}}
+
+    for suffix in ("_cover", "_preset_select"):
+        fake_entry = MagicMock()
+        fake_entry.platform = DOMAIN
+        fake_entry.unique_id = f"AA:BB:CC:DD:EE:FF{suffix}"
+        with patch(
+            "custom_components.tuiss2ha.er.async_get",
+            return_value=MagicMock(async_get=MagicMock(return_value=fake_entry)),
+        ):
+            result = _resolve_blind_from_entity_id(mock_hass, "ignored.id")
+        assert result is blind, f"resolver must accept {suffix}"
+
+
+@pytest.mark.asyncio
+async def test_select_raises_on_unknown_option(mock_hass):
+    """Selecting a preset that no longer exists must surface as an error."""
+    from homeassistant.exceptions import HomeAssistantError
+
+    sel, tb = _make_select(mock_hass)
+    tb.presets = {"Morning": 80}
+
+    with pytest.raises(HomeAssistantError, match="not found"):
+        await sel.async_select_option("Nope")


### PR DESCRIPTION
## What this adds

Per-blind named position presets — same idea as the Tuiss app's "Scenes". Save positions like "Morning" or "Movie", then recall them later without remembering the percentage. People who already set up presets in the Tuiss app can now mirror them in Home Assistant.

### What you get

**A dropdown** for each blind showing your saved presets. Pick one, the blind moves there. The dropdown updates to show which preset you're at right now.

**Four services** to manage presets from automations or scripts:
- Save a preset at a chosen position
- Save a preset at the blind's current position
- Apply a preset (move there)
- Delete a preset

### Tested on real hardware

Verified on a TS2600 blind: save, apply, save-current, delete all work. Dropdown reflects live position after movement.