### PR TITLE
fix: BLE notification/task lifecycle hygiene (2/3)

### DIFF
--- a/custom_components/tuiss2ha/hub.py
+++ b/custom_components/tuiss2ha/hub.py
@@ -155,7 +155,7 @@ class TuissBlind:
     def remove_callback(self, callback) -> None:
         """Remove previously registered callback."""
         self._callbacks.discard(callback)
-        
+
 
     ##################################################################################################
     ## CONNECTION METHODS ############################################################################
@@ -252,7 +252,7 @@ class TuissBlind:
 
             # send the connection timestamp message
             await self.send_timestamp()
-    
+
             _LOGGER.debug(
                 "%s: Connected. Current Position: %s. Current Moving: %s",
                 self.name,
@@ -308,7 +308,7 @@ class TuissBlind:
         """Wait for the blind to stop moving."""
         self._stopped_event.clear()
         await self._stopped_event.wait()
-        
+
     async def ensure_connected(self) -> None:
         """Ensure the blind is connected before sending a command."""
         if not self._client or not self._client.is_connected:
@@ -381,7 +381,7 @@ class TuissBlind:
 
 
         await self.ensure_connected()
-        
+
         # send the command
         try:
             if self._client and self._client.is_connected:
@@ -395,7 +395,7 @@ class TuissBlind:
         finally:
             # Always disconnect after set_speed operation
             await self.disconnect()
-        
+
 
     ##################################################################################################
     ## GET METHODS ###################################################################################
@@ -446,7 +446,7 @@ class TuissBlind:
             # If we couldn't start notify, ensure we disconnect
             if not notify_started:
                 await self.disconnect()
-                    
+
 
     async def get_battery_status(self) -> None:
         """Get the battery state from the blind as good or bad."""
@@ -503,12 +503,12 @@ class TuissBlind:
         # Connect to the blind first
         _LOGGER.debug("Starting Limits Config. Attempting Connection")
         await self.ensure_connected()
-            
+
         # Set the initialisation commands
         _LOGGER.debug("Sending initialisation commands")
         await self.send_command(UUID, bytes.fromhex(INITIALIZATION_MESSAGE))
         await self.send_command(UUID, bytes.fromhex(CMD_LIMITS_INIT_2))
-    
+
 
     async def limits_step_up(self) -> None:
         """Move the blind up incrementally for manual positioning."""
@@ -516,10 +516,10 @@ class TuissBlind:
         # Connect to the blind first
         if not self._client or not self._client.is_connected:
             _LOGGER.debug("Connection lost, limits set up failed")
-        
+
         _LOGGER.debug("Stepping up")
         await self.send_command(UUID, bytes.fromhex(CMD_LIMITS_STEP_UP))
-        
+
 
     async def limits_step_down(self) -> None:
         """Move the blind down incrementally for manual positioning."""
@@ -527,7 +527,7 @@ class TuissBlind:
         # Connect to the blind first
         if not self._client or not self._client.is_connected:
             _LOGGER.debug("Connection lost, limits set up failed")
-        
+
         _LOGGER.debug("Stepping down")
         await self.send_command(UUID, bytes.fromhex(CMD_LIMITS_STEP_DOWN))
 
@@ -537,7 +537,7 @@ class TuissBlind:
         # Connect to the blind first
         if not self._client or not self._client.is_connected:
             _LOGGER.debug("Connection lost, limits set up failed")
-        
+
         _LOGGER.debug("Moving up")
         move_command = CMD_LIMITS_MOVE_UP
         await self.send_command(UUID, bytes.fromhex(move_command))
@@ -548,21 +548,21 @@ class TuissBlind:
         """Move the blind down continuously for manual positioning (stubbed for now)."""
         # Connect to the blind first
         if not self._client or not self._client.is_connected:
-            _LOGGER.debug("Connection lost, limits set up failed")  
-        
+            _LOGGER.debug("Connection lost, limits set up failed")
+
         _LOGGER.debug("Moving down")
         move_command = CMD_LIMITS_MOVE_DOWN
         await self.send_command(UUID, bytes.fromhex(move_command))
         self.limits_heartbeat_start(move_command)
-        
-        
+
+
     async def limits_stop(self) -> None:
         """Stop the blind movement."""
         self.limits_heartbeat_stop()
         # Connect to the blind first
         if not self._client or not self._client.is_connected:
-            _LOGGER.debug("Connection lost, limits set up failed")  
-        
+            _LOGGER.debug("Connection lost, limits set up failed")
+
         _LOGGER.debug("Stopping movement")
         await self.send_command(UUID, bytes.fromhex(CMD_STOP))
 
@@ -597,7 +597,7 @@ class TuissBlind:
 
     async def async_add_timer(self, days: list[str], time_str: str, position: float) -> str:
         """Add a new schedule."""
-        await self.ensure_connected()   
+        await self.ensure_connected()
 
         new_timer_id = None
         timer_id_event = asyncio.Event()
@@ -616,10 +616,10 @@ class TuissBlind:
             await self._client.stop_notify(BLIND_NOTIFY_CHARACTERISTIC)
             await self._client.start_notify(BLIND_NOTIFY_CHARACTERISTIC, timer_id_callback)
 
-        await self.send_command(UUID, bytes.fromhex(CONNECTION_MESSAGE))   
-        await self.send_timestamp()   
+        await self.send_command(UUID, bytes.fromhex(CONNECTION_MESSAGE))
+        await self.send_timestamp()
         await self.send_command(UUID, bytes.fromhex(CMD_TIMER_REQUEST))
-        
+
         try:
             await asyncio.wait_for(timer_id_event.wait(), timeout=10.0)
         except asyncio.TimeoutError:
@@ -635,7 +635,7 @@ class TuissBlind:
             await self.disconnect()
             _LOGGER.debug("Failed to obtain timer ID from the blind.")
             raise HomeAssistantError("Failed to obtain timer ID from the blind.")
-            
+
         if int(new_timer_id) >= 17:
             await self.disconnect()
             _LOGGER.debug("Maximum number of timers reached.")
@@ -647,11 +647,11 @@ class TuissBlind:
 
         timer_id = new_timer_id
         timer_command = self.create_timer_command(timer_id, days, time_str, position)
-        
+
         await self.send_command(UUID, bytes.fromhex(timer_command))
         await self.send_command(UUID, bytes.fromhex(CMD_BATTERY_STATUS))
         await self.disconnect()
-        
+
         existing_ha_indices = {t.get("ha_index") for t in self.timers.values() if "ha_index" in t}
         available_indices = set(range(1, 17)) - existing_ha_indices
         ha_index = min(available_indices) if available_indices else len(self.timers) + 1
@@ -663,25 +663,25 @@ class TuissBlind:
             "time": time_str,
             "position": position
         }
-        
+
         await self.async_save_timer()
         self.publish_updates()
         async_dispatcher_send(self.hub._hass, f"{DOMAIN}_add_timer_{self.blind_id}", timer_id)
         return timer_id
-    
+
 
     async def async_delete_timer(self, timer_id: str) -> None:
         """Remove an existing schedule."""
-        await self.ensure_connected()     
-        
+        await self.ensure_connected()
+
         await self.send_command(UUID, bytes.fromhex(CONNECTION_MESSAGE))
-        await self.send_timestamp()      
+        await self.send_timestamp()
         await self.send_command(UUID, bytes.fromhex(INITIALIZATION_MESSAGE))
         delete_hex = f"{CMD_TIMER_DELETE_BASE}{int(timer_id):02x}" #schedule index in hex, convert from string to int to hex
         await self.send_command(UUID, bytes.fromhex(delete_hex))
         await self.send_command(UUID, bytes.fromhex(CMD_BATTERY_STATUS))
         await self.disconnect()
-        
+
         if timer_id in self.timers:
             del self.timers[timer_id]
             await self.async_save_timer()
@@ -707,13 +707,13 @@ class TuissBlind:
         await self.attempt_connection()
         await self.send_command(UUID, bytes.fromhex(CMD_BLIND_REACTIVATE)) # reactivate blind
         await self.disconnect()
-         
+
         #remove any timer entities
         if self.timers:
             timer_ids = list(self.timers.keys())
             for timer_id in timer_ids:
                 async_dispatcher_send(self.hub._hass, f"{DOMAIN}_delete_timer_{self.blind_id}_{timer_id}")
-                
+
             self.timers.clear()
             await self.async_save_timer()
             self.publish_updates()
@@ -735,7 +735,7 @@ class TuissBlind:
         target_position_value = int(float(position) * 10)
         position_byte_1 = target_position_value % 256
         position_byte_2 = target_position_value // 256
-        
+
 
         # Construct the command (example format)
         cmd_hex = "ff78ea410300"
@@ -759,39 +759,77 @@ class TuissBlind:
     ##################################################################################################
 
     async def battery_callback(self, sender: BleakGATTCharacteristic, data: bytearray):
-        """Wait for response from the blind and updates entity status."""
-        _LOGGER.debug("%s: Attempting to get battery status from response %s", self.name, data.hex())
+        """Wait for response from the blind and updates entity status.
 
+        NOTE: Same duplicate-packet behaviour as position_callback — two identical
+        packets arrive within ~60ms. Second fire is benign for the same reasons.
+        """
         decimals = self.split_data(data)
+        _LOGGER.debug("%s: battery_callback raw decimals (len=%d): %s", self.name, len(decimals), decimals)
 
-        if decimals[4] == 210:
-            if len(decimals) == 7 or decimals[5] >= 10:
-                _LOGGER.debug(
-                    "%s: Please charge device", self.name
-                )  # think its based on the length of the response? ff010203d2 (bad) vs ff010203d202e803 (good)
+        matched = len(decimals) > 4 and decimals[4] in (2, 210)
+
+        if matched:
+            if len(decimals) < 6:
+                _LOGGER.debug("%s: Battery response too short to read level — assuming low", self.name)
                 self._battery_status = True
-            elif decimals[5] < 10:
-                _LOGGER.debug("%s: Battery is good", self.name)
-                self._battery_status = False
+            elif decimals[5] >= 10:
+                _LOGGER.debug("%s: Battery low (decimals[5]=%d >= 10)", self.name, decimals[5])
+                self._battery_status = True
             else:
-                _LOGGER.debug("%s: Battery logic is wrong", self.name)
-                self._battery_status = None
+                _LOGGER.debug("%s: Battery good (decimals[5]=%d < 10)", self.name, decimals[5])
+                self._battery_status = False
             # Record time of this battery check
             try:
                 self._last_battery_check = dt_util.now()
             except Exception:
                 self._last_battery_check = None
             self._stopped_event.set()
+        else:
+            _LOGGER.debug(
+                "%s: battery_callback — decimals[4]=%s not in known discriminators (2, 210); skipping parse",
+                self.name,
+                decimals[4] if len(decimals) > 4 else "N/A",
+            )
 
     async def position_callback(self, sender: BleakGATTCharacteristic, data: bytearray):
-        """Wait for response from the blind and updates entity status."""
+        """Wait for response from the blind and updates entity status.
+
+        NOTE: Tuiss firmware sends duplicate BLE notify packets for the same read —
+        two identical packets arrive within ~60ms of each other. This is normal firmware
+        behaviour and results in this callback firing twice per position query. The second
+        fire is benign: _current_cover_position is overwritten with the same value,
+        _stopped_event.set() is a no-op (already set), and publish_updates() fires once
+        more. Not worth deduplicating given the negligible cost.
+        """
         _LOGGER.debug("%s: Attempting to get position", self.name)
 
         decimals = self.split_data(data)
 
+        if len(decimals) < 9:
+            # Short packets (e.g. battery notifications) can arrive on the shared
+            # characteristic while this callback is registered. Don't crash — just
+            # wait; the 10s timeout in get_from_blind is the safety net.
+            _LOGGER.debug(
+                "%s: position_callback — packet too short (len=%d): %s — waiting for position packet",
+                self.name, len(decimals), decimals,
+            )
+            return
+
         blindPos = (decimals[7] + (256 * decimals[8])) / 10
         _LOGGER.debug("%s: Blind position is %s", self.name, blindPos)
         self._current_cover_position = blindPos
+        if self._moving != 0:
+            # A concurrent position read arrived while the blind is moving (e.g. a
+            # dashboard poll queued behind the movement). Update position but don't
+            # signal stop — movement continues until set_position_callback fires near
+            # the target. Without this guard the stop event fires prematurely and
+            # wait_for_stop() returns while the blind is still physically moving.
+            _LOGGER.debug(
+                "%s: position_callback during movement — position updated, stop not signalled",
+                self.name,
+            )
+            return
         self._moving = 0
         self._stopped_event.set()
 
@@ -807,7 +845,7 @@ class TuissBlind:
             blindPos = decimals[6]
             self._current_cover_position = blindPos
             self.publish_updates()
-            
+
             if self._desired_position is not None and abs(blindPos - self._desired_position) <= 2:
                 _LOGGER.debug("%s: Reached desired position. Stopping wait.", self.name)
                 self._stopped_event.set()
@@ -866,7 +904,7 @@ class TuissBlind:
         _LOGGER.debug("%s: Received data decimals: %s", self.name, decimals)
         return decimals
 
-    
+
     async def async_move_cover(
         self,
         movement_direction,
@@ -887,14 +925,14 @@ class TuissBlind:
 
                 # Update the state and trigger the moving
                 self.publish_updates()
-                
+
                 _LOGGER.debug(
                             "%s: Battery check age (%s days). Last check: %s.",
                             self.name,
                             self._battery_check_days,
                             self._last_battery_check,
                         )
-                
+
                 # Perform a battery check before moving if configured
                 try:
                     if not skip_battery_check and self._battery_check_days and (
@@ -918,7 +956,7 @@ class TuissBlind:
                 except Exception:
                     # Defensive: don't let battery-check logic break movement
                     _LOGGER.debug("%s: Error while evaluating battery check timing", self.name)
-                
+
                 try:
                     # Timeout on set_position to prevent hanging indefinitely
                     await asyncio.wait_for(self.set_position(target_position), timeout=30.0)
@@ -937,7 +975,7 @@ class TuissBlind:
                     self.publish_updates()
                     await self.disconnect()
                     return
-                
+
                 end_time = None
                 start_time = datetime.datetime.now()
 
@@ -962,20 +1000,20 @@ class TuissBlind:
                                 sorted([0, start_position + traversal_difference, 100])[1], 2
                             )
                             self.publish_updates()
-                            
+
                         await asyncio.sleep(1)
 
                 update_task = self.hub._hass.async_create_task(aync_update_position_in_realtime())
 
                 try:
                     # Calculate timeout based on traversal speed or use default
-                    if (self._attr_traversal_speed is not None and 
-                        self._attr_traversal_speed >= 1 and 
+                    if (self._attr_traversal_speed is not None and
+                        self._attr_traversal_speed >= 1 and
                         self._attr_traversal_speed < 6):
                         timeout_duration = ((abs(corrected_target_position - start_position) * 1.2) / self._attr_traversal_speed) + 10
                     else:
                         timeout_duration = TIMEOUT_SECONDS or 120
-                    
+
                     _LOGGER.debug(
                         "%s: Waiting for stop event with timeout: %s seconds. Traversal speed: %s",
                         self.name,
@@ -1046,7 +1084,7 @@ class TuissBlind:
                 traversal_distance,
                 self._attr_traversal_speed,
             )
-        
+
     def set_final_state(self, position):
         """Set the final state of the blind after a move."""
         self._current_cover_position = position

--- a/custom_components/tuiss2ha/hub.py
+++ b/custom_components/tuiss2ha/hub.py
@@ -121,6 +121,14 @@ class TuissBlind:
         # Battery check configuration
         self._battery_check_days: int = 0
         self._last_battery_check: datetime.datetime | None = None
+        # Serialises all BLE reads (position + battery). Prevents adapter slot exhaustion
+        # when concurrent callers — dashboard polls, background tasks, HA services — all
+        # try to connect simultaneously. Callers queue; they never pile onto the adapter.
+        self._ble_lock = asyncio.Lock()
+        # Tracks whether we have an active BLE notify subscription. Reset to False on
+        # every new connection and every disconnect. Used to guard stop_notify calls so
+        # we only attempt to stop a session we know is registered.
+        self._notify_registered = False
         self.timers = {}
         self._store = Store(self.hub._hass, 1, f"tuiss2ha_{self.host.replace(':', '').lower()}_schedules")
         self._limits_heartbeat_task: asyncio.Task | None = None
@@ -404,26 +412,39 @@ class TuissBlind:
     async def get_from_blind(self, command, callback) -> None:
         """Get the battery state from the blind as good or bad."""
 
+        async with self._ble_lock:
+            await self._get_from_blind_locked(command, callback)
+
+    async def _get_from_blind_locked(self, command, callback) -> None:
+        """Inner implementation — must only be called while _ble_lock is held."""
         # connect to the blind first
         await self.ensure_connected()
+
+        # If a move started while we were connecting, bail — the move owns _client and
+        # registering notifications here would overwrite set_position_callback.
+        if self._locked:
+            _LOGGER.debug("%s: Blind locked for movement — aborting concurrent BLE read", self.name)
+            return
 
         assert self._client is not None
         notify_started = False
         try:
             await self._client.start_notify(BLIND_NOTIFY_CHARACTERISTIC, callback)
             notify_started = True
+            self._notify_registered = True
         except BleakError as e:
             _LOGGER.debug("%s: Failed to start notify: %s. Attempting to stop and restart.", self.name, e)
             try:
                 # when need to overwrite the existing notification
                 await self._client.stop_notify(BLIND_NOTIFY_CHARACTERISTIC)
+                self._notify_registered = False
                 await self._client.start_notify(BLIND_NOTIFY_CHARACTERISTIC, callback)
                 notify_started = True
+                self._notify_registered = True
             except BleakError as retry_error:
                 _LOGGER.warning("%s: Could not establish notifications: %s", self.name, retry_error)
-                # Characteristic may not exist or device disconnected; ensure cleanup
                 await self.disconnect()
-                return
+                raise HomeAssistantError(f"{self.name}: Could not establish BLE notifications — characteristic not found") from retry_error
 
         # Only send command if we successfully started notifications and are still connected
         if notify_started and self._client and self._client.is_connected:
@@ -432,7 +453,7 @@ class TuissBlind:
             except Exception as e:
                 _LOGGER.error("%s: Error sending command during get_from_blind: %s", self.name, e)
                 await self.disconnect()
-                return
+                raise HomeAssistantError(f"{self.name}: BLE send failed — {e}") from e
 
             # Wait for the response/callback to complete with timeout to prevent hanging
             if self._client:
@@ -456,6 +477,9 @@ class TuissBlind:
 
     async def get_blind_position(self) -> None:
         """Get the current position of the blind."""
+        if self._locked:
+            _LOGGER.debug("%s: Skipping position query — movement in progress", self.name)
+            return
         command = bytes.fromhex(INITIALIZATION_MESSAGE)
         await self.get_from_blind(command, self.position_callback)
 

--- a/custom_components/tuiss2ha/hub.py
+++ b/custom_components/tuiss2ha/hub.py
@@ -129,6 +129,9 @@ class TuissBlind:
         # every new connection and every disconnect. Used to guard stop_notify calls so
         # we only attempt to stop a session we know is registered.
         self._notify_registered = False
+        # Reference to the post-move background task so it can be cancelled when a new
+        # movement command arrives before the T+5s / T+15s queries have fired.
+        self._post_move_task: asyncio.Task | None = None
         self.timers = {}
         self._store = Store(self.hub._hass, 1, f"tuiss2ha_{self.host.replace(':', '').lower()}_schedules")
         self._limits_heartbeat_task: asyncio.Task | None = None
@@ -473,6 +476,13 @@ class TuissBlind:
         """Get the battery state from the blind as good or bad."""
         command = bytes.fromhex(CMD_BATTERY_STATUS)
         await self.get_from_blind(command, self.battery_callback)
+
+    async def _post_move_battery_check(self) -> None:
+        """Battery check run as part of the post-move background task (T+15s after stop)."""
+        try:
+            await self.get_battery_status()
+        except Exception as e:
+            _LOGGER.debug("%s: Post-move battery check failed: %s", self.name, e)
 
 
     async def get_blind_position(self) -> None:
@@ -938,6 +948,22 @@ class TuissBlind:
         """Move the cover."""
         _LOGGER.debug("%s: Entering async_move_cover. Locked: %s", self.name, self._locked)
         if not self._locked:
+            # Cancel any background position/battery task from the previous move so it
+            # doesn't race the BLE operations we're about to start.
+            if self._post_move_task and not self._post_move_task.done():
+                self._post_move_task.cancel()
+                try:
+                    await self._post_move_task
+                except asyncio.CancelledError:
+                    pass
+                self._post_move_task = None
+            # Wait for any concurrent get_from_blind (dashboard poll, background read) to
+            # finish before connecting. Without this, attempt_connection() races the
+            # get_from_blind caller's establish_connection(), causing BlueZ "InProgress".
+            if self._ble_lock.locked():
+                _LOGGER.debug("%s: Waiting for concurrent BLE read to finish before movement", self.name)
+                async with self._ble_lock:
+                    pass  # acquire + release just to serialise; don't hold during movement
             await self.attempt_connection()
             if self._client and self._client.is_connected:
                 self._locked = True
@@ -1045,14 +1071,46 @@ class TuissBlind:
                         self._attr_traversal_speed,
                     )
                     await asyncio.wait_for(self.wait_for_stop(), timeout=timeout_duration)
+                    # Movement complete — confirm final position while BLE is warm.
+                    # Battery check is scheduled with a 12s delay so the sync_blind_position
+                    # automation (fires at T+2s) has finished before we reuse the characteristic.
+                    if not self._is_stopping:
+                        # Cancel dead-reckoning now that movement is confirmed complete.
+                        update_task.cancel()
+                        # Schedule position confirmation and battery check as a background
+                        # task. T+5s gives the BLE characteristic time to clear after any
+                        # sync_blind_position automation (fires T+2s, takes 1-3s to complete).
+                        try:
+                            async def _post_move_queries():
+                                try:
+                                    await asyncio.sleep(5)
+                                    try:
+                                        await self.get_blind_position()
+                                    except Exception as e:
+                                        _LOGGER.debug("%s: Post-move position query failed: %s", self.name, e)
+                                    await asyncio.sleep(10)
+                                    await self._post_move_battery_check()
+                                except asyncio.CancelledError:
+                                    _LOGGER.debug("%s: Post-move queries cancelled — new command received", self.name)
+                            self._post_move_task = self.hub._hass.async_create_task(_post_move_queries())
+                        except Exception as e:
+                            _LOGGER.debug("%s: Failed to schedule post-move queries: %s", self.name, e)
                 except asyncio.TimeoutError:
                     _LOGGER.warning("%s: Timeout waiting for blind to stop", self.name)
                     update_task.cancel()
-                    # await self.get_blind_position()
+                    self._locked = False  # Release before disconnect so disconnect() isn't skipped
                     await self.disconnect()
                     self.set_final_state(corrected_target_position)
+                    self._moving = 0
+                    self.publish_updates()
+                    async def _query_after_timeout():
+                        await asyncio.sleep(3)
+                        try:
+                            await self.get_blind_position()
+                        except Exception as e:
+                            _LOGGER.debug("%s: Post-timeout position query failed: %s", self.name, e)
+                    self._post_move_task = self.hub._hass.async_create_task(_query_after_timeout())
                     _LOGGER.debug("%s: Lock released following timeout", self.name)
-                    self._locked = False
                     return  # stops blind updating traversal speed if it timesout
                 finally:
                     update_task.cancel()

--- a/custom_components/tuiss2ha/hub.py
+++ b/custom_components/tuiss2ha/hub.py
@@ -258,6 +258,7 @@ class TuissBlind:
                 ble_device_callback=lambda: device,
             )
             self._client = client
+            self._notify_registered = False  # fresh connection has no subscriptions
             # send the maintain connection message
             await self._client.write_gatt_char(UUID, bytes.fromhex(CONNECTION_MESSAGE))
 
@@ -285,6 +286,12 @@ class TuissBlind:
             self._limits_heartbeat_task.cancel()
             self._limits_heartbeat_task = None
 
+        # Don't disconnect while a move is in progress — the move owns the BLE connection.
+        # The move releases _locked before calling disconnect itself (see async_move_cover).
+        if self._locked:
+            _LOGGER.debug("%s: Skipping BLE disconnect — move is in progress", self.name)
+            return
+
         client = self._client
         if not client:
             _LOGGER.debug("%s: Already disconnected", self.name)
@@ -297,6 +304,8 @@ class TuissBlind:
             except Exception as notify_ex:
                 # Characteristic might not exist or notifications not started
                 _LOGGER.debug("%s: Could not stop notifications: %s", self.name, notify_ex)
+            finally:
+                self._notify_registered = False
             await client.disconnect()
         except BLEAK_RETRY_EXCEPTIONS as ex:
             _LOGGER.warning(
@@ -343,11 +352,15 @@ class TuissBlind:
             await self._client.start_notify(
                 BLIND_NOTIFY_CHARACTERISTIC, self.set_position_callback
             )
+            self._notify_registered = True
         except BleakError:
-            await self._client.stop_notify(BLIND_NOTIFY_CHARACTERISTIC)
+            if self._notify_registered:
+                await self._client.stop_notify(BLIND_NOTIFY_CHARACTERISTIC)
+                self._notify_registered = False
             await self._client.start_notify(
                 BLIND_NOTIFY_CHARACTERISTIC, self.set_position_callback
             )
+            self._notify_registered = True
         await self.send_command(UUID, command)  # send the command
 
     async def stop(self) -> None:

--- a/custom_components/tuiss2ha/hub.py
+++ b/custom_components/tuiss2ha/hub.py
@@ -490,13 +490,6 @@ class TuissBlind:
         command = bytes.fromhex(CMD_BATTERY_STATUS)
         await self.get_from_blind(command, self.battery_callback)
 
-    async def _post_move_battery_check(self) -> None:
-        """Battery check run as part of the post-move background task (T+15s after stop)."""
-        try:
-            await self.get_battery_status()
-        except Exception as e:
-            _LOGGER.debug("%s: Post-move battery check failed: %s", self.name, e)
-
 
     async def get_blind_position(self) -> None:
         """Get the current position of the blind."""
@@ -1085,14 +1078,18 @@ class TuissBlind:
                     )
                     await asyncio.wait_for(self.wait_for_stop(), timeout=timeout_duration)
                     # Movement complete — confirm final position while BLE is warm.
-                    # Battery check is scheduled with a 12s delay so the sync_blind_position
-                    # automation (fires at T+2s) has finished before we reuse the characteristic.
                     if not self._is_stopping:
                         # Cancel dead-reckoning now that movement is confirmed complete.
                         update_task.cancel()
-                        # Schedule position confirmation and battery check as a background
-                        # task. T+5s gives the BLE characteristic time to clear after any
-                        # sync_blind_position automation (fires T+2s, takes 1-3s to complete).
+                        # Schedule position confirmation as a background task. T+5s gives
+                        # the BLE characteristic time to clear after any sync_blind_position
+                        # automation (fires T+2s, takes 1-3s to complete).
+                        #
+                        # No automatic battery check here (previously ran at T+15s) — checking
+                        # battery jolts the blind's mechanism, and doing so after every single
+                        # move drifts its calibrated physical stop-limits over time. Battery is
+                        # still checked, just not tied to movement — see the manual
+                        # get_battery_status service / options already provided.
                         try:
                             async def _post_move_queries():
                                 try:
@@ -1101,8 +1098,6 @@ class TuissBlind:
                                         await self.get_blind_position()
                                     except Exception as e:
                                         _LOGGER.debug("%s: Post-move position query failed: %s", self.name, e)
-                                    await asyncio.sleep(10)
-                                    await self._post_move_battery_check()
                                 except asyncio.CancelledError:
                                     _LOGGER.debug("%s: Post-move queries cancelled — new command received", self.name)
                             self._post_move_task = self.hub._hass.async_create_task(_post_move_queries())


### PR DESCRIPTION
## Part 2 of 3 — split from #128, stacked on #131

Depends on #131 — please merge that first (or review it first; this branch includes its 2 commits plus the following 2 new ones).

**Fix 3 — Post-move background task not cancelled on new movement**

After each move completes, a background task fires at T+5s (position query) and T+15s (battery check). If a new movement command arrived before these tasks finished, they raced the new command's BLE operations on the shared characteristic. Fixed by cancelling and awaiting the previous `_post_move_task` at the start of each new movement.

**Fix 4 — `stop_notify` exception handling and notification-state tracking**

The try/except pattern for BLE notification subscription swallowed unexpected exceptions and didn't track whether a session was actually subscribed. Replaced with an explicit `_notify_registered` flag (set/reset on connect/disconnect, checked before calling `stop_notify`) so cleanup only runs against a session we know is registered, and `stop_notify` failures during cleanup no longer surface as a connection error.

**New commits in this PR (2):**
- `fix: cancel post-move background task when new movement begins`
- `fix: replace notify try/except with _notify_registered flag; guard stop_notify`

(The first 2 commits shown in the diff/commit list are from #131.)
