### PR TITLE
Fix Last Connection Error sensor falling back to 'unknown'

### DIFF
--- a/custom_components/tuiss2ha/sensor.py
+++ b/custom_components/tuiss2ha/sensor.py
@@ -539,7 +539,6 @@ class TuissLastConnectionErrorSensor(SensorEntity):
             manufacturer=self.blind.hub.manufacturer,
             model=self.blind.model,
         )
-        self._attr_native_value = self.blind._last_connection_error
 
     @property
     def available(self) -> bool:
@@ -548,8 +547,19 @@ class TuissLastConnectionErrorSensor(SensorEntity):
 
     @property
     def native_value(self) -> str | None:
-        """Return the state of the sensor."""
-        return self.blind._last_connection_error or "None"
+        """Return the state of the sensor.
+
+        HA caps entity states at 255 chars; connection errors can exceed that
+        (BleakError text + interference/USB hints), so truncate the state and
+        expose the full message via extra_state_attributes.
+        """
+        error = self.blind._last_connection_error or "None"
+        return error[:252] + "..." if len(error) > 255 else error
+
+    @property
+    def extra_state_attributes(self) -> dict[str, str]:
+        """Return the full, untruncated error message."""
+        return {"full_error": self.blind._last_connection_error or "None"}
 
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""
@@ -562,5 +572,4 @@ class TuissLastConnectionErrorSensor(SensorEntity):
     @callback
     def _handle_update(self) -> None:
         """Handle updated data from the hub."""
-        self._attr_native_value = self.blind._last_connection_error or "None"
         self.async_write_ha_state()

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -81,3 +81,40 @@ async def test_cover_methods_raise_homeassistanterror_on_device_errors(mock_hass
 
     with pytest.raises(HomeAssistantError):
         await cover_entity.async_stop_cover()
+
+
+def test_last_connection_error_sensor_truncates_long_state():
+    """State >255 chars truncated; full message in attribute (HA caps state at 255)."""
+    from custom_components.tuiss2ha.sensor import TuissLastConnectionErrorSensor
+
+    blind = MagicMock()
+    blind.blind_id = "AABBCCDDEEFF"
+    blind.name = "Test"
+    blind.hub.manufacturer = "Tuiss"
+    blind.model = "TS5200"
+    long_err = "2026-09-01 06:02:30: " + "x" * 400
+    blind._last_connection_error = long_err
+
+    sensor = TuissLastConnectionErrorSensor(blind)
+    assert len(sensor.native_value) <= 255
+    assert sensor.native_value.endswith("...")
+    assert sensor.extra_state_attributes["full_error"] == long_err
+
+
+def test_last_connection_error_sensor_short_state_untouched():
+    """Short error passes through unchanged; None -> 'None'."""
+    from custom_components.tuiss2ha.sensor import TuissLastConnectionErrorSensor
+
+    blind = MagicMock()
+    blind.blind_id = "AABBCCDDEEFF"
+    blind.name = "Test"
+    blind.hub.manufacturer = "Tuiss"
+    blind.model = "TS5200"
+
+    blind._last_connection_error = "short error"
+    sensor = TuissLastConnectionErrorSensor(blind)
+    assert sensor.native_value == "short error"
+
+    blind._last_connection_error = None
+    assert sensor.native_value == "None"
+    assert sensor.extra_state_attributes["full_error"] == "None"


### PR DESCRIPTION
## What was wrong

The **Last Connection Error** diagnostic sensor showed `unknown` whenever a real connection error happened. Home Assistant limits a sensor's state to 255 characters, and the sensor was putting the whole error message (timestamp + Bluetooth error + interference/USB hints) into the state. Longer messages got rejected by HA and the sensor fell back to `unknown`, so the information the sensor exists to show was lost.

Example message that triggered it (over 255 chars):

```
State ...: C5:A5:10:35:EB:5E - C5:A5:10:35:EB:5E: Failed to connect after 10 attempt(s): Error ESP_GATT_ERROR while connecting: ... Extension cables reduce USB 3 port interference for sensor.home_office_blind_last_connection_error is longer than 255, falling back to unknown
```

## The fix

- Truncate the sensor **state** to 255 characters (`[:252] + "..."`).
- Add a new `full_error` **attribute** carrying the complete, untruncated message. Attributes are not subject to the 255-char limit, so no diagnostic detail is lost.
- Removed a leftover `_attr_native_value` assignment now that `native_value` is a property.

## Testing

- Added two tests: truncation branch (long error → state ≤ 255, full text in attribute) and short/None passthrough.
- Full suite: 87 passed.
- Verified live on a real blind — the sensor now shows the actual error instead of `unknown`.

## Relation to open PRs

PR #133 also touches `_last_connection_error` (clearing it on reconnect) but does not address the 255-char state limit, so this is complementary and does not overlap.

## Note on other sensors

Checked every other sensor and cover attribute. None are affected: the rest are numbers, timestamps, or short fixed strings, and cover error text lives in exception messages/attributes, which aren't capped at 255.

<img width="592" height="639" alt="tuiss" src="https://github.com/user-attachments/assets/327e3feb-2e70-47eb-9af8-5f5e158b770d" />

